### PR TITLE
Update to typeshed version of gRPC stubs

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -304,20 +304,6 @@ pycodestyle = "*"
 setuptools = "*"
 
 [[package]]
-name = "grpc-stubs"
-version = "1.53.0.5"
-description = "Mypy stubs for gRPC"
-optional = false
-python-versions = ">=3.6"
-files = [
-    {file = "grpc-stubs-1.53.0.5.tar.gz", hash = "sha256:3e1b642775cbc3e0c6332cfcedfccb022176db87e518757bef3a1241397be406"},
-    {file = "grpc_stubs-1.53.0.5-py3-none-any.whl", hash = "sha256:04183fb65a1b166a1febb9627e3d9647d3926ccc2dfe049fe7b6af243428dbe1"},
-]
-
-[package.dependencies]
-grpcio = "*"
-
-[[package]]
 name = "grpcio"
 version = "1.71.0"
 description = "HTTP/2-based RPC framework"
@@ -1388,6 +1374,20 @@ files = [
 ]
 
 [[package]]
+name = "types-grpcio"
+version = "1.0.0.20250426"
+description = "Typing stubs for grpcio"
+optional = false
+python-versions = ">=3.9"
+files = [
+    {file = "types_grpcio-1.0.0.20250426-py3-none-any.whl", hash = "sha256:7931b4ec0bedb8af7c53910ed54edeb8be964251ecf0c4f0234f95e472a90ce3"},
+    {file = "types_grpcio-1.0.0.20250426.tar.gz", hash = "sha256:a079034b1c32520b1218bd50187539352b8ff495cf9b91a7c98772a3baf5f1d1"},
+]
+
+[package.dependencies]
+types-protobuf = "*"
+
+[[package]]
 name = "types-protobuf"
 version = "5.29.1.20250403"
 description = "Typing stubs for protobuf"
@@ -1412,4 +1412,4 @@ files = [
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9"
-content-hash = "681a64f5d10bd10d379d6dcfd3984a20e57bae9ecd298965676528cf5258d81c"
+content-hash = "8f60befb298fc183823a63f1d02835395b93ece3ef563b535673cb54a0b046e4"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ protobuf = {version=">=4.21"}
 ni-measurement-plugin-sdk = {version=">=2.3"}
 
 [tool.poetry.group.dev.dependencies]
-grpc-stubs = "^1.53"
+types-grpcio = ">=1.0"
 types-protobuf = ">=4.21"
 
 [tool.poetry.group.lint.dependencies]


### PR DESCRIPTION
### What does this Pull Request accomplish?

Replace `grpc-stubs` with `types-grpcio`.

### Why should this Pull Request be merged?

The `grpc-stubs` package has been integrated into typeshed and is now archived.

### What testing has been done?

Ran mypy.