### PR TITLE
pyproject.toml: Set tool.black.line-length

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,6 +56,7 @@ extend_exclude = ".tox,docs,src/ni/pythonpanel/v1"
 
 [tool.black]
 extend-exclude = '\.tox/|docs/|src/ni/pythonpanel/v1/'
+line-length = 100
 
 [tool.mypy]
 files = "examples/,src/nipanel/,tests/"


### PR DESCRIPTION
### What does this Pull Request accomplish?

Configure black the same way as ni-python-styleguide does, in case it is run directly. Copied from https://github.com/ni/nidaqmx-python/blob/master/pyproject.toml

### Why should this Pull Request be merged?

@jfriedri-ni encountered a situation where `nps lint` and `black` disagreed about formatting.

### What testing has been done?

None