### PR TITLE
github: Specify required permissions for CI and PR workflows

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -8,6 +8,11 @@ on:
   workflow_call:
   workflow_dispatch:
 
+permissions:
+  contents: read
+  checks: write
+  pull-requests: write
+
 jobs:
   check_nipanel:
     name: Check nipanel

--- a/.github/workflows/PR.yml
+++ b/.github/workflows/PR.yml
@@ -8,6 +8,11 @@ on:
   workflow_call:
   workflow_dispatch:
 
+permissions:
+  contents: read
+  checks: write
+  pull-requests: write
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true


### PR DESCRIPTION
### What does this Pull Request accomplish?

Make the CI and PR workflows work with `Workflow permissions` set to `Read repository contents and packages permissions` in the repo's GitHub Actions settings. 

The https://github.com/EnricoMi/publish-unit-test-result-action action requires the ability to write to checks and PRs. Also, since this is a private repo, reading the repo contents is opt-in.

### Why should this Pull Request be merged?

Principle of least privilege.

### What testing has been done?

Tested with nitypes repo: https://github.com/ni/nitypes-python/pull/53

I will not flip the switch in the settings until this is merged, to avoid disrupting other developers.