### PR TITLE
github: Specify permissions on the job level, not the workflow level

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -8,11 +8,6 @@ on:
   workflow_call:
   workflow_dispatch:
 
-permissions:
-  contents: read
-  checks: write
-  pull-requests: write
-
 jobs:
   check_nipanel:
     name: Check nipanel
@@ -29,3 +24,7 @@ jobs:
     uses: ./.github/workflows/report_test_results.yml
     needs: [run_unit_tests]
     if: always()
+    permissions:
+      contents: read
+      checks: write
+      pull-requests: write

--- a/.github/workflows/PR.yml
+++ b/.github/workflows/PR.yml
@@ -8,11 +8,6 @@ on:
   workflow_call:
   workflow_dispatch:
 
-permissions:
-  contents: read
-  checks: write
-  pull-requests: write
-
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
@@ -21,3 +16,7 @@ jobs:
   run_ci:
     name: Run CI
     uses: ./.github/workflows/CI.yml
+    permissions:
+      contents: read
+      checks: write
+      pull-requests: write

--- a/.github/workflows/report_test_results.yml
+++ b/.github/workflows/report_test_results.yml
@@ -4,15 +4,14 @@ on:
   workflow_call:
   workflow_dispatch:
 
-permissions:
-  contents: read
-  checks: write
-  pull-requests: write
-
 jobs:
   report_test_results:
     name: Report test results
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      checks: write
+      pull-requests: write
     steps:
       - name: Check out repo
         uses: actions/checkout@v4


### PR DESCRIPTION
### What does this Pull Request accomplish?

Specify permissions on the job level, not the workflow level. Specifying permissions on the workflow level grants the specified permissions to all jobs in the workflow, which gives some jobs permissions that they don't need.

CI.yml has multiple jobs, and only one needs additional privileges. I also updated workflows that have only one job. 

### Why should this Pull Request be merged?

Principle of least privilege

### What testing has been done?

PR build