### PR TITLE
docs: Enable Intersphinx links to nitypes

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -73,7 +73,6 @@ def setup(sphinx):
 exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
 
 
-# TODO: AB#3120159 - Update nipanel intersphinx mapping for nitypes
 intersphinx_mapping = {
     "grpc": ("https://grpc.github.io/grpc/python/", None),
     "measurement-plugin-python": (


### PR DESCRIPTION
### What does this Pull Request accomplish?

Add https://nitypes.readthedocs.io/en/latest/ to the intersphinx mapping.

### Why should this Pull Request be merged?

Enable nipanel documentation to link to nitypes documentation.

Closes [AB#3120159](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/3120159)

### What testing has been done?

PR build