### PR TITLE
Add __version__ support to nipanel.

### DIFF
--- a/src/nipanel/__init__.py
+++ b/src/nipanel/__init__.py
@@ -14,3 +14,4 @@ Panel.__module__ = __name__
 StreamlitPanel.__module__ = __name__
 
 __version__ = version(__name__)
+"""nipanel version string."""


### PR DESCRIPTION
### What does this Pull Request accomplish?

Similar to a recent change in `nitypes`, this adds the ability to query the package version using `nipanel.__version__`.

### Why should this Pull Request be merged?

So that clients of this package can query the version.
Consistency with `nitypes`

### What testing has been done?

I ran the following code in the poetry venv with these changes and it returned the correct version:
```
>>> import nipanel
>>> nipanel.__version__
'0.1.0'
```