### PR TITLE
Add unit tests for _convert.to_any() and _convert.from_any()

### DIFF
--- a/tests/unit/test_convert.py
+++ b/tests/unit/test_convert.py
@@ -122,9 +122,7 @@ def test___paneltype_value___from_any___valid_python_value(
 # ========================================================
 def _assert_any_and_unpack(packed_message: any_pb2.Any, unpack_destination: Any) -> None:
     assert isinstance(packed_message, any_pb2.Any)
-    did_unpack = packed_message.Unpack(unpack_destination)
-    if not did_unpack:
-        raise ValueError(f"Failed to unpack Any with type '{packed_message.TypeName()}'")
+    assert packed_message.Unpack(unpack_destination)
 
 
 def _pack_into_any(proto_value: Union[_AnyWrappersPb2, _AnyPanelPbTypes]) -> any_pb2.Any:


### PR DESCRIPTION
### What does this Pull Request accomplish?

Adds unit tests for `_convert.to_any()` and `_convert.from_any()`

### Why should this Pull Request be merged?

Since we are going to be adding more protobuf types (Scalar, Analog Waveform, etc.) to this _convert file soon, having unit tests is a good way to try and prevent breakages for existing functionality.

### What testing has been done?

pytest, mypy, styleguide