### PR TITLE
github: Group+schedule GHA and Python updates and disable automerge

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,21 +1,40 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "branchPrefix": "users/renovate/",
+  "timezone": "US/Central",
   "extends": [
     "config:recommended",
-    ":maintainLockFilesWeekly",
-    ":automergePatch",
-    "schedule:automergeDaily",
     "helpers:pinGitHubActionDigestsToSemver",
     ":enableVulnerabilityAlerts"
   ],
   "packageRules": [
     {
-      // Do not update Python packages when new versions are released. Instead,
-      // let lock file maintenance update them once a week.
-      "enabled": false,
-      "matchCategories": ["python"]
+      // Update GitHub Actions on weekends.
+      "matchCategories": ["github-actions"],
+      "groupName": "GitHub Actions",
+      "groupSlug": "github",
+      "schedule": [
+        "* * * * 0,6"
+      ]
+    },
+    {
+      // Update Python packages on weekends.
+      "matchCategories": ["python"],
+      "groupName": "Python packages",
+      "groupSlug": "python",
+      "schedule": [
+        "* * * * 0,6"
+      ]
     }
   ],
+  "lockFileMaintenance": {
+    // Maintain lock files on early Tuesday mornings. This is primarily to
+    // update indirect dependencies that aren't handled by the Python packages
+    // group.
+    "enabled": true,
+    "schedule": [
+      "* 0-3 * * 2"
+    ]
+  },
   "osvVulnerabilityAlerts": true
 }


### PR DESCRIPTION
### What does this Pull Request accomplish?

Reconfigure Renovate again:
- Set the timezone to US/Central for scheduling.
- Update GitHub Actions on weekends and group updates into a single PR.
- Update Python packages on weekends and group updates into a single PR.
- Move lock file maintenance to early Tuesday morning. This is primarily for indirect dependencies.
- Disable automerge because we don't need it with a less frequent update schedule.

### Why should this Pull Request be merged?

Relying on lock file maintenance for all Python package updates has unexpected downsides:
- Python packages no longer show up in Dependency Dashboard
- The lock file maintenance PRs do not include changelogs for the updated dependencies

### What testing has been done?

```
C:\Dev\nitypes-python2\.github>npx --yes --package renovate -- renovate-config-validator
 INFO: Validating renovate.json5
 INFO: Config validated successfully
```