### PR TITLE
github: Remove lockFileMaintenance from matchUpdateTypes

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -18,8 +18,9 @@
       ]
     },
     {
-      // Update Python packages on weekends.
+      // Update Python packages on weekends, separate from lockFileMaintenance.
       "matchCategories": ["python"],
+      "matchUpdateTypes": ["major", "minor", "patch", "rollback", "replacement"],
       "groupName": "Python packages",
       "groupSlug": "python",
       "schedule": [


### PR DESCRIPTION
### What does this Pull Request accomplish?

Specify `matchUpdateTypes` for Python packages, without `lockFileMaintenance`.

### Why should this Pull Request be merged?

Keep `lockFileMaintenance` separate. The logfile says
```
DEBUG: Grouping lockfile maintenance with other update types is not supported (branch="users/renovate/python")
```

### What testing has been done?

Ran Renovate on a personal fork of the nitypes repo: https://github.com/bkeryan/nitypes-python/pull/3
