### PR TITLE
Update nipanel to use has_start_time instead of has_timestamp.

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -3179,4 +3179,4 @@ files = [
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.9,<4.0,!=3.9.7"
-content-hash = "6eaa1c4b3e03542a99eac841ab79bb33c351a29cdee2c876030b8fd1f938b85c"
+content-hash = "4d8fe33d72a4d5a4eab2fed3db3068518a165cac5172632a00ec9f577e404145"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ protobuf = {version=">=4.21"}
 ni-measurement-plugin-sdk = {version=">=2.3"}
 typing-extensions = ">=4.13.2"
 streamlit = ">=1.24"
-nitypes = {version=">=0.1.0dev2", allow-prereleases=true}
+nitypes = {version=">=0.1.0dev3", allow-prereleases=true}
 numpy = [
   { version = ">=1.22", python = ">=3.9,<3.12", markers = "implementation_name != 'pypy'" },
   { version = ">=1.26", python = ">=3.12,<3.13", markers = "implementation_name != 'pypy'" },

--- a/src/nipanel/converters/protobuf_types.py
+++ b/src/nipanel/converters/protobuf_types.py
@@ -106,7 +106,7 @@ class DoubleAnalogWaveformConverter(Converter[AnalogWaveform[np.float64], Double
 
     def to_protobuf_message(self, python_value: AnalogWaveform[np.float64]) -> DoubleAnalogWaveform:
         """Convert the Python AnalogWaveform to a protobuf DoubleAnalogWaveform."""
-        if python_value.timing.has_timestamp:
+        if python_value.timing.has_start_time:
             bin_datetime = convert_datetime(bt.DateTime, python_value.timing.start_time)
             precision_timestamp = self._pt_converter.to_protobuf_message(bin_datetime)
         else:


### PR DESCRIPTION
### What does this Pull Request accomplish?

In a previous submission to `nitypes-python`, I added a `Timing.get_start_time` property so that we could reference it in `nipanel-python` instead of using `get_timestamp`.

This change makes the `nipanel-python` part of this change.

`has_start_time` and `has_timestamp` are equivalent, so there is no functional change in this PR.

In order to get access to `has_start_time` I had to update to the latest version of `nitypes`.

### Why should this Pull Request be merged?

Finishes out [AB#3166841](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/3166841)

### What testing has been done?

Unit tests, mypy, styleguide.