### PR TITLE
Add numeric and enum inputs to the simple graph example

### DIFF
--- a/examples/simple_graph/amplitude_enum.py
+++ b/examples/simple_graph/amplitude_enum.py
@@ -1,0 +1,11 @@
+"""Enumeration for amplitude values used in the simple graph example."""
+
+import enum
+
+
+class AmplitudeEnum(enum.IntEnum):
+    """Enumeration for amplitude values."""
+
+    SMALL = 1
+    MEDIUM = 5
+    BIG = 10

--- a/examples/simple_graph/simple_graph.py
+++ b/examples/simple_graph/simple_graph.py
@@ -5,6 +5,7 @@ import time
 from pathlib import Path
 
 import numpy as np
+from amplitude_enum import AmplitudeEnum
 
 import nipanel
 
@@ -12,8 +13,6 @@ import nipanel
 panel_script_path = Path(__file__).with_name("simple_graph_panel.py")
 panel = nipanel.create_panel(panel_script_path)
 
-amplitude = 1.0
-frequency = 1.0
 num_points = 100
 
 try:
@@ -22,16 +21,19 @@ try:
 
     # Generate and update the sine wave data periodically
     while True:
-        time_points = np.linspace(0, num_points, num_points)
-        sine_values = amplitude * np.sin(frequency * time_points)
+        amplitude_enum = AmplitudeEnum(panel.get_value("amplitude_enum", AmplitudeEnum.SMALL.value))
+        base_frequency = panel.get_value("base_frequency", 1.0)
 
+        # Slowly vary the total frequency for a more dynamic visualization
+        frequency = base_frequency + 0.5 * math.sin(time.time() / 5.0)
+
+        time_points = np.linspace(0, num_points, num_points)
+        sine_values = amplitude_enum.value * np.sin(frequency * time_points)
+
+        panel.set_value("frequency", frequency)
         panel.set_value("time_points", time_points.tolist())
         panel.set_value("sine_values", sine_values.tolist())
-        panel.set_value("amplitude", amplitude)
-        panel.set_value("frequency", frequency)
 
-        # Slowly vary the frequency for a more dynamic visualization
-        frequency = 1.0 + 0.5 * math.sin(time.time() / 5.0)
         time.sleep(0.1)
 
 except KeyboardInterrupt:

--- a/examples/simple_graph/simple_graph_panel.py
+++ b/examples/simple_graph/simple_graph_panel.py
@@ -1,6 +1,7 @@
 """A Streamlit visualization panel for the simple_graph.py example script."""
 
 import streamlit as st
+from amplitude_enum import AmplitudeEnum
 from streamlit_echarts import st_echarts
 
 import nipanel
@@ -8,23 +9,34 @@ import nipanel
 
 st.set_page_config(page_title="Simple Graph Example", page_icon="📈", layout="wide")
 st.title("Simple Graph Example")
+col1, col2, col3, col4, col5, col6 = st.columns(6)
 
 panel = nipanel.get_panel_accessor()
+
+with col1:
+    amplitude_tuple = st.selectbox(
+        "Amplitude",
+        options=[(e.name, e.value) for e in AmplitudeEnum],
+        format_func=lambda x: x[0],
+        index=0,
+    )
+    amplitude_enum = AmplitudeEnum[amplitude_tuple[0]]
+    panel.set_value("amplitude_enum", amplitude_enum)
+with col2:
+    base_frequency = st.number_input("Base Frequency", value=1.0, step=0.1)
+    panel.set_value("base_frequency", base_frequency)
+
+with col3:
+    frequency = panel.get_value("frequency", 0.0)
+    st.metric("Frequency", f"{frequency:.2f} Hz")
+
 time_points = panel.get_value("time_points", [0.0])
 sine_values = panel.get_value("sine_values", [0.0])
-amplitude = panel.get_value("amplitude", 1.0)
-frequency = panel.get_value("frequency", 1.0)
-
-col1, col2, col3, col4, col5 = st.columns(5)
-with col1:
-    st.metric("Amplitude", f"{amplitude:.2f}")
-with col2:
-    st.metric("Frequency", f"{frequency:.2f} Hz")
-with col3:
-    st.metric("Min Value", f"{min(sine_values):.3f}")
 with col4:
-    st.metric("Max Value", f"{max(sine_values):.3f}")
+    st.metric("Min Value", f"{min(sine_values):.3f}")
 with col5:
+    st.metric("Max Value", f"{max(sine_values):.3f}")
+with col6:
     st.metric("Data Points", len(sine_values))
 
 # Prepare data for echarts


### PR DESCRIPTION
### What does this Pull Request accomplish?

This PR adds inputs to the Simple Graph example. The Amplitude is an enum, and the base frequency is a numeric. The automatically-varying frequency is added to the base frequency, so that the graph still looks dynamic.

### Why should this Pull Request be merged?

We need examples of using inputs on Streamlit panels.

### What testing has been done?

![GraphInputs](https://github.com/user-attachments/assets/44cdb893-606a-419b-aa1f-4a490cd935e9)
