### PR TITLE
Type match with collections.abc.Collection and some exclusions

### DIFF
--- a/src/nipanel/_convert.py
+++ b/src/nipanel/_convert.py
@@ -79,6 +79,14 @@ _CONVERTER_FOR_PYTHON_TYPE = {entry.python_typename: entry for entry in _CONVERT
 _CONVERTER_FOR_GRPC_TYPE = {entry.protobuf_typename: entry for entry in _CONVERTIBLE_TYPES}
 _SUPPORTED_PYTHON_TYPES = _CONVERTER_FOR_PYTHON_TYPE.keys()
 
+_SKIPPED_COLLECTIONS = (
+    str,  # Handled by StrConverter
+    bytes,  # Handled by BytesConverter
+    dict,  # Unsupported data type
+    enum.Enum,  # Handled by IntConverter
+    Vector,  # Handled by VectorConverter
+)
+
 
 def to_any(python_value: object) -> any_pb2.Any:
     """Convert a Python object to a protobuf Any."""
@@ -191,5 +199,5 @@ def _is_collection_for_convert(python_value: object) -> bool:
     # str, bytes, dict, Enum, and Vector are instances of Collection
     # but they are either invalid types or have custom converters.
     return isinstance(python_value, Collection) and not isinstance(
-        python_value, (str, bytes, dict, enum.Enum, Vector)
+        python_value, _SKIPPED_COLLECTIONS
     )

--- a/src/nipanel/_convert.py
+++ b/src/nipanel/_convert.py
@@ -112,8 +112,6 @@ def _get_best_matching_type(python_value: object) -> str:
             # collection type.
             value_is_collection = _is_collection_for_convert(working_python_value)
         container_types.append(Collection)
-        if len(container_types) > 5:
-            raise RuntimeError(f"Infinite collection loop: {type(working_python_value)}")
 
     best_matching_type = None
     candidates = _get_candidate_strings(underlying_parents)

--- a/src/nipanel/_convert.py
+++ b/src/nipanel/_convert.py
@@ -196,8 +196,6 @@ def _get_additional_type_info_string(python_value: object) -> str:
 
 
 def _is_collection_for_convert(python_value: object) -> bool:
-    # str, bytes, dict, Enum, and Vector are instances of Collection
-    # but they are either invalid types or have custom converters.
     return isinstance(python_value, Collection) and not isinstance(
         python_value, _SKIPPED_COLLECTIONS
     )


### PR DESCRIPTION
### What does this Pull Request accomplish?

Updates the gRPC conversion logic to determine if something is a "collection" by checking if it's an instance of `collections.abc.Collection`, but not an instance of several other types that are technically collections but are handled with a custom converter.

Exclusions:
- `str`: Has a separate converter
- `bytes`: Has a separate converter
- `enum.Enum`: Converted as ints
- `dict`: Not a valid type to convert
- `ni.protobuf.types.Vector`: Has a separate converter

### Why should this Pull Request be merged?

[AB#3175632](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/3175632)

### What testing has been done?

Unit tests, mypy, pyright, styleguide

### Previous RFC Comments
This is a Request for Comment (at least for now) PR addressing this research item about using `collections.abc` instead of `list, set, frozen_set, etc.` to determine collections for conversion.

[AB#3175632](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/3175632)

The question to answer here is whether the implementation in this PR is better and/or more maintainable than keeping a "inclusion" list of the types of collections we support. Note that I do not know if the exclusion list is complete, but it does satisfy the unit tests that were already written. We'll have to maintain the exclusion list, so we'll have to decide whether that's easier than maintaining the inclusion list.