### PR TITLE
Update daqmx examples to use AnalogWaveform

### DIFF
--- a/examples/nidaqmx/nidaqmx_analog_input_filtering/nidaqmx_analog_input_filtering.py
+++ b/examples/nidaqmx/nidaqmx_analog_input_filtering/nidaqmx_analog_input_filtering.py
@@ -17,6 +17,7 @@ from nidaqmx.constants import (  # noqa: E402
     Slope,
     StrainGageBridgeType,
     TerminalConfiguration,
+    UsageTypeAI,
 )
 from nidaqmx.errors import DaqError  # noqa: E402
 
@@ -31,7 +32,8 @@ system = nidaqmx.system.System.local()
 available_channel_names = []
 for dev in system.devices:
     for chan in dev.ai_physical_chans:
-        available_channel_names.append(chan.name)
+        if UsageTypeAI.VOLTAGE in chan.ai_meas_types:
+            available_channel_names.append(chan.name)
 panel.set_value("available_channel_names", available_channel_names)
 
 available_trigger_sources = [""]
@@ -40,111 +42,121 @@ for dev in system.devices:
         for term in dev.terminals:
             available_trigger_sources.append(term)
 panel.set_value("available_trigger_sources", available_trigger_sources)
+
 try:
-    panel.set_value("daq_error", "")
     print(f"Panel URL: {panel.panel_url}")
     print(f"Waiting for the 'Run' button to be pressed...")
     print(f"(Press Ctrl + C to quit)")
     while True:
         while not panel.get_value("is_running", False):
             time.sleep(0.1)
-        # How to use nidaqmx: https://nidaqmx-python.readthedocs.io/en/stable/
-        with nidaqmx.Task() as task:
 
-            chan_type = panel.get_value("chan_type", "1")
+        print(f"Running...")
+        try:
+            # How to use nidaqmx: https://nidaqmx-python.readthedocs.io/en/stable/
+            panel.set_value("daq_error", "")
+            with nidaqmx.Task() as task:
 
-            if chan_type == "2":
-                chan = task.ai_channels.add_ai_current_chan(
-                    panel.get_value("physical_channel", ""),
-                    max_val=panel.get_value("max_value_current", 0.01),
-                    min_val=panel.get_value("min_value_current", -0.01),
-                    ext_shunt_resistor_val=panel.get_value("shunt_resistor_value", 249.0),
-                    shunt_resistor_loc=panel.get_value(
-                        "shunt_location", CurrentShuntResistorLocation.EXTERNAL
-                    ),
-                    units=panel.get_value("units", CurrentUnits.AMPS),
-                )
+                chan_type = panel.get_value("chan_type", "1")
 
-            elif chan_type == "3":
-                chan = task.ai_channels.add_ai_strain_gage_chan(
-                    panel.get_value("physical_channel", ""),
-                    nominal_gage_resistance=panel.get_value("gage_resistance", 350.0),
-                    voltage_excit_source=ExcitationSource.EXTERNAL,  # Only mode that works
-                    max_val=panel.get_value("max_value_strain", 0.001),
-                    min_val=panel.get_value("min_value_strain", -0.001),
-                    poisson_ratio=panel.get_value("poisson_ratio", 0.3),
-                    lead_wire_resistance=panel.get_value("wire_resistance", 0.0),
-                    initial_bridge_voltage=panel.get_value("initial_voltage", 0.0),
-                    gage_factor=panel.get_value("gage_factor", 2.0),
-                    voltage_excit_val=panel.get_value("voltage_excitation_value", 0.0),
-                    strain_config=panel.get_value(
-                        "strain_configuration", StrainGageBridgeType.FULL_BRIDGE_I
-                    ),
-                )
-            else:
-                chan = task.ai_channels.add_ai_voltage_chan(
-                    panel.get_value("physical_channel", ""),
-                    terminal_config=panel.get_value(
-                        "terminal_configuration", TerminalConfiguration.DEFAULT
-                    ),
-                    max_val=panel.get_value("max_value_voltage", 5.0),
-                    min_val=panel.get_value("min_value_voltage", -5.0),
-                )
-            task.timing.cfg_samp_clk_timing(
-                source=panel.get_value("source", ""),  # "" - means Onboard Clock (default value)
-                rate=panel.get_value("rate", 1000.0),
-                sample_mode=AcquisitionType.CONTINUOUS,
-                samps_per_chan=panel.get_value("total_samples", 100),
-            )
-            panel.set_value("sample_rate", task.timing.samp_clk_rate)
-            # Not all hardware supports all filter types.
-            # Refer to your device documentation for more information.
-            if panel.get_value("filter", "Filter") == "Filter":
-                chan.ai_filter_enable = True
-                chan.ai_filter_freq = panel.get_value("filter_freq", 0.0)
-                chan.ai_filter_response = panel.get_value("filter_response", FilterResponse.COMB)
-                chan.ai_filter_order = panel.get_value("filter_order", 1)
-                panel.set_value("actual_filter_freq", chan.ai_filter_freq)
-                panel.set_value("actual_filter_response", chan.ai_filter_response)
-                panel.set_value("actual_filter_order", chan.ai_filter_order)
-            else:
-                panel.set_value("actual_filter_freq", 0.0)
-                panel.set_value("actual_filter_response", FilterResponse.COMB)
-                panel.set_value("actual_filter_order", 0)
-            # Not all hardware supports all filter types.
-            # Refer to your device documentation for more information.
-            trigger_type = panel.get_value("trigger_type")
-            if trigger_type == "5":
-                task.triggers.start_trigger.cfg_anlg_edge_start_trig(
-                    trigger_source=panel.get_value("analog_source", ""),
-                    trigger_slope=panel.get_value("slope", Slope.FALLING),
-                    trigger_level=panel.get_value("level", 0.0),
-                )
+                if chan_type == "2":
+                    chan = task.ai_channels.add_ai_current_chan(
+                        panel.get_value("physical_channel", ""),
+                        max_val=panel.get_value("max_value_current", 0.01),
+                        min_val=panel.get_value("min_value_current", -0.01),
+                        ext_shunt_resistor_val=panel.get_value("shunt_resistor_value", 249.0),
+                        shunt_resistor_loc=panel.get_value(
+                            "shunt_location", CurrentShuntResistorLocation.EXTERNAL
+                        ),
+                        units=panel.get_value("units", CurrentUnits.AMPS),
+                    )
 
-            if trigger_type == "2":
-                task.triggers.start_trigger.cfg_dig_edge_start_trig(
-                    trigger_source=panel.get_value("digital_source", ""),
-                    trigger_edge=panel.get_value("edge", Edge.FALLING),
+                elif chan_type == "3":
+                    chan = task.ai_channels.add_ai_strain_gage_chan(
+                        panel.get_value("physical_channel", ""),
+                        nominal_gage_resistance=panel.get_value("gage_resistance", 350.0),
+                        voltage_excit_source=ExcitationSource.EXTERNAL,  # Only mode that works
+                        max_val=panel.get_value("max_value_strain", 0.001),
+                        min_val=panel.get_value("min_value_strain", -0.001),
+                        poisson_ratio=panel.get_value("poisson_ratio", 0.3),
+                        lead_wire_resistance=panel.get_value("wire_resistance", 0.0),
+                        initial_bridge_voltage=panel.get_value("initial_voltage", 0.0),
+                        gage_factor=panel.get_value("gage_factor", 2.0),
+                        voltage_excit_val=panel.get_value("voltage_excitation_value", 0.0),
+                        strain_config=panel.get_value(
+                            "strain_configuration", StrainGageBridgeType.FULL_BRIDGE_I
+                        ),
+                    )
+                else:
+                    chan = task.ai_channels.add_ai_voltage_chan(
+                        panel.get_value("physical_channel", ""),
+                        terminal_config=panel.get_value(
+                            "terminal_configuration", TerminalConfiguration.DEFAULT
+                        ),
+                        max_val=panel.get_value("max_value_voltage", 5.0),
+                        min_val=panel.get_value("min_value_voltage", -5.0),
+                    )
+                task.timing.cfg_samp_clk_timing(
+                    source=panel.get_value(
+                        "source", ""
+                    ),  # "" - means Onboard Clock (default value)
+                    rate=panel.get_value("rate", 1000.0),
+                    sample_mode=AcquisitionType.CONTINUOUS,
+                    samps_per_chan=panel.get_value("total_samples", 100),
                 )
-                task.triggers.start_trigger.anlg_edge_hyst = hysteresis = panel.get_value(
-                    "hysteresis", 0.0
-                )
+                panel.set_value("sample_rate", task.timing.samp_clk_rate)
+                # Not all hardware supports all filter types.
+                # Refer to your device documentation for more information.
+                if panel.get_value("filter", "Filter") == "Filter":
+                    chan.ai_filter_enable = True
+                    chan.ai_filter_freq = panel.get_value("filter_freq", 0.0)
+                    chan.ai_filter_response = panel.get_value(
+                        "filter_response", FilterResponse.COMB
+                    )
+                    chan.ai_filter_order = panel.get_value("filter_order", 1)
+                    panel.set_value("actual_filter_freq", chan.ai_filter_freq)
+                    panel.set_value("actual_filter_response", chan.ai_filter_response)
+                    panel.set_value("actual_filter_order", chan.ai_filter_order)
+                else:
+                    panel.set_value("actual_filter_freq", 0.0)
+                    panel.set_value("actual_filter_response", FilterResponse.COMB)
+                    panel.set_value("actual_filter_order", 0)
+                # Not all hardware supports all filter types.
+                # Refer to your device documentation for more information.
+                trigger_type = panel.get_value("trigger_type")
+                if trigger_type == "5":
+                    task.triggers.start_trigger.cfg_anlg_edge_start_trig(
+                        trigger_source=panel.get_value("analog_source", ""),
+                        trigger_slope=panel.get_value("slope", Slope.FALLING),
+                        trigger_level=panel.get_value("level", 0.0),
+                    )
 
-            try:
-                task.start()
-                while panel.get_value("is_running", False):
-                    waveform = task.read_waveform(number_of_samples_per_channel=100)
-                    panel.set_value("waveform", waveform)
-            except KeyboardInterrupt:
-                pass
-            finally:
-                task.stop()
-                panel.set_value("is_running", False)
+                if trigger_type == "2":
+                    task.triggers.start_trigger.cfg_dig_edge_start_trig(
+                        trigger_source=panel.get_value("digital_source", ""),
+                        trigger_edge=panel.get_value("edge", Edge.FALLING),
+                    )
+                    task.triggers.start_trigger.anlg_edge_hyst = hysteresis = panel.get_value(
+                        "hysteresis", 0.0
+                    )
 
-except DaqError as e:
-    daq_error = str(e)
-    print(daq_error)
-    panel.set_value("daq_error", daq_error)
+                try:
+                    task.start()
+                    while panel.get_value("is_running", False):
+                        waveform = task.read_waveform(number_of_samples_per_channel=100)
+                        panel.set_value("waveform", waveform)
+                except KeyboardInterrupt:
+                    pass
+                finally:
+                    task.stop()
+                    panel.set_value("is_running", False)
+                    print(f"Stopped")
+
+        except DaqError as e:
+            daq_error = str(e)
+            panel.set_value("daq_error", daq_error)
+            panel.set_value("is_running", False)
+            print(f"ERRORED")
 
 except KeyboardInterrupt:
     pass

--- a/examples/nidaqmx/nidaqmx_analog_input_filtering/nidaqmx_analog_input_filtering_panel.py
+++ b/examples/nidaqmx/nidaqmx_analog_input_filtering/nidaqmx_analog_input_filtering_panel.py
@@ -62,9 +62,9 @@ with left_col:
     with st.container(border=True):
         with st.container(border=True):
             if panel.get_value("is_running", True):
-                st.button("Stop", key="stop_button", on_click=click_stop)
+                st.button("⏹️ Stop", key="stop_button", on_click=click_stop)
             elif not panel.get_value("is_running", True) and panel.get_value("daq_error", "") == "":
-                run_button = st.button("Run", key="run_button", on_click=click_start)
+                run_button = st.button("▶️ Run", key="run_button", on_click=click_start)
             else:
                 st.error(
                     f"There was an error running the script. Fix the issue and re-run nidaqmx_analog_input_filtering.py \n\n {panel.get_value('daq_error', '')}"

--- a/examples/nidaqmx/nidaqmx_analog_input_filtering/nidaqmx_analog_input_filtering_panel.py
+++ b/examples/nidaqmx/nidaqmx_analog_input_filtering/nidaqmx_analog_input_filtering_panel.py
@@ -2,8 +2,8 @@
 
 from typing import cast
 
-import hightime as ht
 import extra_streamlit_components as stx  # type: ignore[import-untyped]
+import hightime as ht
 import streamlit as st
 from nidaqmx.constants import (
     CurrentShuntResistorLocation,
@@ -21,11 +21,11 @@ import nipanel
 from nipanel.controls import enum_selectbox
 
 
-def click_start():
+def _click_start() -> None:
     panel.set_value("is_running", True)
 
 
-def click_stop():
+def _click_stop() -> None:
     panel.set_value("is_running", False)
 
 
@@ -62,9 +62,9 @@ with left_col:
     with st.container(border=True):
         with st.container(border=True):
             if panel.get_value("is_running", True):
-                st.button("⏹️ Stop", key="stop_button", on_click=click_stop)
+                st.button("⏹️ Stop", key="stop_button", on_click=_click_stop)
             elif not panel.get_value("is_running", True) and panel.get_value("daq_error", "") == "":
-                run_button = st.button("▶️ Run", key="run_button", on_click=click_start)
+                run_button = st.button("▶️ Run", key="run_button", on_click=_click_start)
             else:
                 st.error(
                     f"There was an error running the script. Fix the issue and re-run nidaqmx_analog_input_filtering.py \n\n {panel.get_value('daq_error', '')}"

--- a/examples/nidaqmx/nidaqmx_analog_input_filtering/nidaqmx_analog_input_filtering_panel.py
+++ b/examples/nidaqmx/nidaqmx_analog_input_filtering/nidaqmx_analog_input_filtering_panel.py
@@ -57,15 +57,14 @@ st.markdown(
     unsafe_allow_html=True,
 )
 
+if panel.get_value("is_running", True):
+    st.button("⏹️ Stop", key="stop_button", on_click=_click_stop)
+else:
+    st.button("▶️ Run", key="run_button", on_click=_click_start)
 
 with left_col:
     with st.container(border=True):
         with st.container(border=True):
-            if panel.get_value("is_running", True):
-                st.button("⏹️ Stop", key="stop_button", on_click=_click_stop)
-            elif not panel.get_value("is_running", True):
-                run_button = st.button("▶️ Run", key="run_button", on_click=_click_start)
-
             st.title("Channel Settings")
             st.selectbox(
                 options=panel.get_value("available_channel_names", [""]),

--- a/examples/nidaqmx/nidaqmx_analog_input_filtering/nidaqmx_analog_input_filtering_panel.py
+++ b/examples/nidaqmx/nidaqmx_analog_input_filtering/nidaqmx_analog_input_filtering_panel.py
@@ -29,11 +29,8 @@ def _click_stop() -> None:
     panel.set_value("is_running", False)
 
 
-st.set_page_config(page_title="Analog Input Filtering", page_icon="📈", layout="wide")
-st.title("Analog Input - Filtering")
+st.set_page_config(page_title="NI-DAQmx - Analog Input - Filtering", page_icon="📈", layout="wide")
 panel = nipanel.get_streamlit_panel_accessor()
-
-left_col, right_col = st.columns(2)
 
 
 st.markdown(
@@ -57,101 +54,103 @@ st.markdown(
     unsafe_allow_html=True,
 )
 
+st.header("NI-DAQmx - Analog Input - Filtering")
 if panel.get_value("is_running", True):
     st.button("⏹️ Stop", key="stop_button", on_click=_click_stop)
 else:
     st.button("▶️ Run", key="run_button", on_click=_click_start)
 
+left_col, right_col = st.columns(2)
+
 with left_col:
     with st.container(border=True):
-        with st.container(border=True):
-            st.title("Channel Settings")
-            st.selectbox(
-                options=panel.get_value("available_channel_names", [""]),
-                index=0,
-                label="Physical Channels",
-                disabled=panel.get_value("is_running", False),
-                key="physical_channel",
-            )
-            enum_selectbox(
-                panel,
-                label="Terminal Configuration",
-                value=TerminalConfiguration.DEFAULT,
-                disabled=panel.get_value("is_running", False),
-                key="terminal_configuration",
-            )
+        st.header("Channel Settings")
+        st.selectbox(
+            options=panel.get_value("available_channel_names", [""]),
+            index=0,
+            label="Physical Channels",
+            disabled=panel.get_value("is_running", False),
+            key="physical_channel",
+        )
+        enum_selectbox(
+            panel,
+            label="Terminal Configuration",
+            value=TerminalConfiguration.DEFAULT,
+            disabled=panel.get_value("is_running", False),
+            key="terminal_configuration",
+        )
 
-            st.title("Timing Settings")
+        st.header("Timing Settings")
 
-            st.selectbox(
-                "Sample Clock Source",
-                options=panel.get_value("available_trigger_sources", [""]),
-                index=0,
-                disabled=panel.get_value("is_running", False),
-                key="source",
-            )
-            st.number_input(
-                "Sample Rate",
-                value=1000.0,
-                min_value=1.0,
-                step=1.0,
-                disabled=panel.get_value("is_running", False),
-                key="rate",
-            )
-            st.number_input(
-                "Number of Samples",
-                value=100,
-                min_value=1,
-                step=1,
-                disabled=panel.get_value("is_running", False),
-                key="total_samples",
-            )
-            st.number_input(
-                "Actual Sample Rate",
-                value=panel.get_value("sample_rate", 1000.0),
-                key="actual_sample_rate",
-                step=1.0,
-                disabled=True,
-            )
-            st.title("Filtering Settings")
+        st.selectbox(
+            "Sample Clock Source",
+            options=panel.get_value("available_trigger_sources", [""]),
+            index=0,
+            disabled=panel.get_value("is_running", False),
+            key="source",
+        )
+        st.number_input(
+            "Sample Rate",
+            value=1000.0,
+            min_value=1.0,
+            step=1.0,
+            disabled=panel.get_value("is_running", False),
+            key="rate",
+        )
+        st.number_input(
+            "Number of Samples",
+            value=100,
+            min_value=1,
+            step=1,
+            disabled=panel.get_value("is_running", False),
+            key="total_samples",
+        )
+        st.number_input(
+            "Actual Sample Rate",
+            value=panel.get_value("sample_rate", 1000.0),
+            key="actual_sample_rate",
+            step=1.0,
+            disabled=True,
+        )
+        st.header("Filtering Settings")
 
-            st.selectbox(
-                "Filter",
-                options=["No Filtering", "Filter"],
-                disabled=panel.get_value("is_running", False),
-                key="filter",
-            )
-            enum_selectbox(
-                panel,
-                label="Filter Response",
-                value=FilterResponse.COMB,
-                disabled=panel.get_value("is_running", False),
-                key="filter_response",
-            )
+        st.selectbox(
+            "Filter",
+            options=["No Filtering", "Filter"],
+            disabled=panel.get_value("is_running", False),
+            key="filter",
+        )
+        enum_selectbox(
+            panel,
+            label="Filter Response",
+            value=FilterResponse.COMB,
+            disabled=panel.get_value("is_running", False),
+            key="filter_response",
+        )
 
-            filter_freq = st.number_input(
-                "Filtering Frequency",
-                value=1000.0,
-                step=1.0,
-                disabled=panel.get_value("is_running", False),
-            )
-            filter_order = st.number_input(
-                "Filter Order",
-                min_value=0,
-                max_value=1,
-                value=1,
-                disabled=panel.get_value("is_running", False),
-            )
-            st.selectbox(
-                "Actual Filter Frequency",
-                options=[panel.get_value("actual_filter_freq", 0.0)],
-                disabled=True,
-            )
-            st.selectbox(
-                "Actual Filter Order",
-                options=[panel.get_value("actual_filter_order", 0)],
-                disabled=True,
-            )
+        filter_freq = st.number_input(
+            "Filtering Frequency",
+            value=1000.0,
+            step=1.0,
+            disabled=panel.get_value("is_running", False),
+        )
+        filter_order = st.number_input(
+            "Filter Order",
+            min_value=0,
+            max_value=1,
+            value=1,
+            disabled=panel.get_value("is_running", False),
+        )
+        st.selectbox(
+            "Actual Filter Frequency",
+            options=[panel.get_value("actual_filter_freq", 0.0)],
+            disabled=True,
+        )
+        st.selectbox(
+            "Actual Filter Order",
+            options=[panel.get_value("actual_filter_order", 0)],
+            disabled=True,
+        )
 
 with right_col:
 
@@ -161,7 +160,7 @@ with right_col:
         )
     else:
         with st.container(border=True):
-            st.title("Acquired Data")
+            st.header("Acquired Data")
 
             waveform = panel.get_value("waveform", AnalogWaveform())
             if waveform.sample_count == 0:
@@ -207,16 +206,12 @@ with right_col:
             }
             st_echarts(options=graph, height="400px", key="graph", width="100%")
 
-    st.title("Trigger Settings")
+    st.header("Trigger Settings")
     trigger_type = stx.tab_bar(
         data=[
             stx.TabBarItemData(id=1, title="No Trigger", description=""),
             stx.TabBarItemData(id=2, title="Digital Start", description=""),
-            stx.TabBarItemData(id=3, title="Digital Pause", description=""),
-            stx.TabBarItemData(id=4, title="Digital Reference", description=""),
-            stx.TabBarItemData(id=5, title="Analog Start", description=""),
-            stx.TabBarItemData(id=6, title="Analog Pause", description=""),
-            stx.TabBarItemData(id=7, title="Analog Reference", description=""),
+            stx.TabBarItemData(id=3, title="Analog Start", description=""),
         ],
         default=1,
     )
@@ -243,16 +238,6 @@ with right_col:
             )
     if trigger_type == "3":
         with st.container(border=True):
-            st.write(
-                "This trigger type is not supported in continuous sample timing. Refer to your device documentation for more information on which triggers are supported"
-            )
-    if trigger_type == "4":
-        with st.container(border=True):
-            st.write(
-                "This trigger type is not supported in continuous sample timing. Refer to your device documentation for more information on which triggers are supported"
-            )
-    if trigger_type == "5":
-        with st.container(border=True):
             analog_source = st.text_input("Source", "APFI0", key="analog_source")
             enum_selectbox(
                 panel,
@@ -269,17 +254,7 @@ with right_col:
                 key="hysteriesis",
             )
 
-    if trigger_type == "6":
-        with st.container(border=True):
-            st.write(
-                "This trigger type is not supported in continuous sample timing. Refer to your device documentation for more information on which triggers are supported"
-            )
-    if trigger_type == "7":
-        with st.container(border=True):
-            st.write(
-                "This trigger type is not supported in continuous sample timing. Refer to your device documentation for more information on which triggers are supported."
-            )
-    st.title("Task Types")
+    st.header("Task Types")
 
     chan_type = stx.tab_bar(
         data=[
@@ -293,7 +268,7 @@ with right_col:
     panel.set_value("chan_type", chan_type)
     if chan_type == "1":
         with st.container(border=True):
-            st.title("Voltage Data")
+            st.header("Voltage Data")
             channel_left, channel_right = st.columns(2)
             with channel_left:
                 max_value_voltage = st.number_input(
@@ -314,7 +289,7 @@ with right_col:
 
     if chan_type == "2":
         with st.container(border=True):
-            st.title("Current Data")
+            st.header("Current Data")
             channel_left, channel_right = st.columns(2)
             with channel_left:
                 enum_selectbox(
@@ -352,7 +327,7 @@ with right_col:
                 )
     if chan_type == "3":
         with st.container(border=True):
-            st.title("Strain Gage Data")
+            st.header("Strain Gage Data")
             channel_left, channel_right = st.columns(2)
             with channel_left:
                 min_value_strain = st.number_input(
@@ -375,7 +350,7 @@ with right_col:
                     disabled=panel.get_value("is_running", False),
                     key="strain_units",
                 )
-                st.title("Strain Gage Information")
+                st.header("Strain Gage Information")
                 gage_factor = st.number_input(
                     "Gage Factor",
                     value=2.0,
@@ -397,7 +372,7 @@ with right_col:
                     disabled=panel.get_value("is_running", False),
                     key="poisson_ratio",
                 )
-            st.title("Bridge Information")
+            st.header("Bridge Information")
             enum_selectbox(
                 panel,
                 label="Strain Configuration",

--- a/examples/nidaqmx/nidaqmx_analog_output_voltage/nidaqmx_analog_output_voltage.py
+++ b/examples/nidaqmx/nidaqmx_analog_output_voltage/nidaqmx_analog_output_voltage.py
@@ -10,7 +10,7 @@ import nidaqmx  # noqa: E402 # Must import after setting os environment variable
 import nidaqmx.stream_writers  # noqa: E402
 import nidaqmx.system  # noqa: E402
 import numpy as np  # noqa: E402
-from nidaqmx.constants import AcquisitionType, Edge  # noqa: E402
+from nidaqmx.constants import AcquisitionType, Edge, UsageTypeAO  # noqa: E402
 from nidaqmx.errors import DaqError  # noqa: E402
 from nitypes.waveform import AnalogWaveform, SampleIntervalMode, Timing  # noqa: E402
 
@@ -18,13 +18,15 @@ import nipanel  # noqa: E402
 
 panel_script_path = Path(__file__).with_name("nidaqmx_analog_output_voltage_panel.py")
 panel = nipanel.create_streamlit_panel(panel_script_path)
+panel.set_value("is_running", False)
 
 system = nidaqmx.system.System.local()
 
 available_channel_names = []
 for dev in system.devices:
     for chan in dev.ao_physical_chans:
-        available_channel_names.append(chan.name)
+        if UsageTypeAO.VOLTAGE in chan.ao_output_types:
+            available_channel_names.append(chan.name)
 panel.set_value("available_channel_names", available_channel_names)
 
 available_trigger_sources = [""]
@@ -33,87 +35,92 @@ for dev in system.devices:
         for term in dev.terminals:
             available_trigger_sources.append(term)
 panel.set_value("available_trigger_sources", available_trigger_sources)
-panel.set_value("is_running", False)
+
 try:
-    panel.set_value("daq_error", "")
     print(f"Panel URL: {panel.panel_url}")
     print(f"Waiting for the 'Run' button to be pressed...")
     print(f"(Press Ctrl + C to quit)")
     while True:
         while not panel.get_value("is_running", False):
             time.sleep(0.1)
-        # How to use nidaqmx: https://nidaqmx-python.readthedocs.io/en/stable/
-        with nidaqmx.Task() as task:
-            chan = task.ao_channels.add_ao_voltage_chan(
-                panel.get_value("physical_channel", ""),
-                max_val=panel.get_value("max_value_voltage", 5.0),
-                min_val=panel.get_value("min_value_voltage", -5.0),
-            )
 
-            sample_rate = panel.get_value("rate", 1000.0)
-            num_samples = panel.get_value("total_samples", 1000)
-            frequency = panel.get_value("frequency", 10.0)
-            amplitude = panel.get_value("amplitude", 1.0)
-
-            task.timing.cfg_samp_clk_timing(
-                source=panel.get_value("source", ""),  # "" - OnboardClock
-                rate=sample_rate,
-                sample_mode=AcquisitionType.CONTINUOUS,
-            )
-            # Not all hardware supports all trigger types.
-            # Refer to your device documentation for more information.
-            trigger_type = panel.get_value("trigger_type")
-
-            if trigger_type == 2:
-                task.triggers.start_trigger.cfg_dig_edge_start_trig(
-                    trigger_source=panel.get_value("digital_source", ""),
-                    trigger_edge=panel.get_value("edge", Edge.FALLING),
+        print(f"Running...")
+        try:
+            # How to use nidaqmx: https://nidaqmx-python.readthedocs.io/en/stable/
+            panel.set_value("daq_error", "")
+            with nidaqmx.Task() as task:
+                chan = task.ao_channels.add_ao_voltage_chan(
+                    panel.get_value("physical_channel", ""),
+                    max_val=panel.get_value("max_value_voltage", 5.0),
+                    min_val=panel.get_value("min_value_voltage", -5.0),
                 )
-            else:
-                pass
 
-            panel.set_value("sample_rate", task.timing.samp_clk_rate)
-            t = np.arange(num_samples) / sample_rate
-            wave_type = panel.get_value("wave_type", "Sine Wave")
+                sample_rate = panel.get_value("rate", 1000.0)
+                num_samples = panel.get_value("total_samples", 1000)
+                frequency = panel.get_value("frequency", 10.0)
+                amplitude = panel.get_value("amplitude", 1.0)
 
-            if wave_type == "Sine Wave":
-                waveform = AnalogWaveform.from_array_1d(
-                    amplitude * np.sin(2 * np.pi * frequency * t)
+                task.timing.cfg_samp_clk_timing(
+                    source=panel.get_value("source", ""),  # "" - OnboardClock
+                    rate=sample_rate,
+                    sample_mode=AcquisitionType.CONTINUOUS,
                 )
-            elif wave_type == "Square Wave":
-                waveform = AnalogWaveform.from_array_1d(
-                    amplitude * np.sign(np.sin(2 * np.pi * frequency * t))
+                # Not all hardware supports all trigger types.
+                # Refer to your device documentation for more information.
+                trigger_type = panel.get_value("trigger_type")
+
+                if trigger_type == 2:
+                    task.triggers.start_trigger.cfg_dig_edge_start_trig(
+                        trigger_source=panel.get_value("digital_source", ""),
+                        trigger_edge=panel.get_value("edge", Edge.FALLING),
+                    )
+                else:
+                    pass
+
+                panel.set_value("sample_rate", task.timing.samp_clk_rate)
+                t = np.arange(num_samples) / sample_rate
+                wave_type = panel.get_value("wave_type", "Sine Wave")
+
+                if wave_type == "Sine Wave":
+                    waveform = AnalogWaveform.from_array_1d(
+                        amplitude * np.sin(2 * np.pi * frequency * t)
+                    )
+                elif wave_type == "Square Wave":
+                    waveform = AnalogWaveform.from_array_1d(
+                        amplitude * np.sign(np.sin(2 * np.pi * frequency * t))
+                    )
+                else:
+                    waveform = AnalogWaveform.from_array_1d(
+                        amplitude * (2 * np.abs(2 * (t * frequency % 1) - 1) - 1)
+                    )
+                waveform.timing = Timing(
+                    sample_interval_mode=SampleIntervalMode.REGULAR,
+                    sample_interval=ht.timedelta(seconds=1.0 / sample_rate),
                 )
-            else:
-                waveform = AnalogWaveform.from_array_1d(
-                    amplitude * (2 * np.abs(2 * (t * frequency % 1) - 1) - 1)
+                waveform.units = chan.ao_voltage_units.name
+
+                writer = nidaqmx.stream_writers.AnalogSingleChannelWriter(
+                    task.out_stream, auto_start=False  # pyright: ignore[reportArgumentType]
                 )
-            waveform.timing = Timing(
-                sample_interval_mode=SampleIntervalMode.REGULAR,
-                sample_interval=ht.timedelta(seconds=1.0 / sample_rate),
-            )
-            waveform.units = chan.ao_voltage_units.name
+                writer.write_waveform(waveform)
+                panel.set_value("waveform", waveform)
+                try:
+                    task.start()
+                    while panel.get_value("is_running", False):
+                        time.sleep(0.1)
 
-            writer = nidaqmx.stream_writers.AnalogSingleChannelWriter(
-                task.out_stream, auto_start=False  # pyright: ignore[reportArgumentType]
-            )
-            writer.write_waveform(waveform)
-            panel.set_value("waveform", waveform)
-            try:
-                task.start()
-                while panel.get_value("is_running", False):
-                    time.sleep(0.1)
+                except KeyboardInterrupt:
+                    break
+                finally:
+                    task.stop()
+                    panel.set_value("is_running", False)
+                    print(f"Stopped")
 
-            except KeyboardInterrupt:
-                break
-            finally:
-                task.stop()
-                panel.set_value("is_running", False)
-
-except DaqError as e:
-    daq_error = str(e)
-    print(daq_error)
-    panel.set_value("daq_error", daq_error)
+        except DaqError as e:
+            daq_error = str(e)
+            panel.set_value("daq_error", daq_error)
+            panel.set_value("is_running", False)
+            print(f"ERRORED")
 
 except KeyboardInterrupt:
     pass

--- a/examples/nidaqmx/nidaqmx_analog_output_voltage/nidaqmx_analog_output_voltage.py
+++ b/examples/nidaqmx/nidaqmx_analog_output_voltage/nidaqmx_analog_output_voltage.py
@@ -5,11 +5,10 @@ import time
 from pathlib import Path
 
 os.environ["NIDAQMX_ENABLE_WAVEFORM_SUPPORT"] = "1"
+import hightime as ht  # noqa: E402
 import nidaqmx  # noqa: E402 # Must import after setting os environment variable
 import nidaqmx.stream_writers  # noqa: E402
 import nidaqmx.system  # noqa: E402
-import hightime as ht  # noqa: E402
-import datetime as dt  # noqa: E402
 import numpy as np  # noqa: E402
 from nidaqmx.constants import AcquisitionType, Edge  # noqa: E402
 from nidaqmx.errors import DaqError  # noqa: E402

--- a/examples/nidaqmx/nidaqmx_analog_output_voltage/nidaqmx_analog_output_voltage_panel.py
+++ b/examples/nidaqmx/nidaqmx_analog_output_voltage/nidaqmx_analog_output_voltage_panel.py
@@ -31,14 +31,14 @@ st.markdown(
     """
     <style>
      div.stNumberInput {
-        max-width: 190px !important;
+        max-width: 250px !important;
     }
     div.stTextInput {
-        max-width: 190px !important;
+        max-width: 250px !important;
     }
    
     div[data-baseweb="select"] {
-        width: 190px !important; /* Adjust the width as needed */
+        width: 250px !important; /* Adjust the width as needed */
     }
     </style>
     <style>
@@ -54,21 +54,17 @@ with left_col:
         is_running = panel.get_value("is_running", False)
         if is_running:
             st.button("⏹️ Stop", key="stop_button", on_click=_click_stop)
-        elif not is_running and panel.get_value("daq_error", "") == "":
+        elif not is_running:
             run_button = st.button("▶️ Run", key="run_button", on_click=_click_start)
-        else:
-            st.error(
-                f"There was an error running the script. Fix the issue and re-run nidaqmx_analog_output_voltage.py \n\n {panel.get_value('daq_error', '')}"
-            )
 
         st.title("Channel Settings")
-        physical_channel = st.selectbox(
-            options=panel.get_value("available_channel_names", ["Mod2/ai0"]),
+        st.selectbox(
+            options=panel.get_value("available_channel_names", [""]),
             index=0,
             label="Physical Channels",
             disabled=panel.get_value("is_running", False),
+            key="physical_channel",
         )
-        panel.set_value("physical_channel", physical_channel)
 
         max_value_voltage = st.number_input(
             "Max Value",
@@ -141,49 +137,54 @@ with left_col:
         panel.set_value("wave_type", wave_type)
 
 with right_col:
-    with st.container(border=True):
-        st.title("Output")
+    if panel.get_value("daq_error", "") != "":
+        st.error(
+            f"There was an error running the script. Fix the issue and click Run again. \n\n {panel.get_value('daq_error', '')}"
+        )
+    else:
+        with st.container(border=True):
+            st.title("Output")
 
-        waveform = panel.get_value("waveform", AnalogWaveform())
-        if waveform.sample_count == 0:
-            time_labels = ["0.000"]
-        else:
-            timestamps = cast(
-                list[ht.datetime],
-                list(waveform.timing.get_timestamps(0, waveform.sample_count)),
-            )
-            time_labels = [f"{ts.second}.{ts.microsecond//1000:03d}" for ts in timestamps]
+            waveform = panel.get_value("waveform", AnalogWaveform())
+            if waveform.sample_count == 0:
+                time_labels = ["0.000"]
+            else:
+                timestamps = cast(
+                    list[ht.datetime],
+                    list(waveform.timing.get_timestamps(0, waveform.sample_count)),
+                )
+                time_labels = [f"{ts.second}.{ts.microsecond//1000:03d}" for ts in timestamps]
 
-        graph = {
-            "animation": False,
-            "tooltip": {"trigger": "axis"},
-            "legend": {"data": [waveform.units]},
-            "xAxis": {
-                "type": "category",
-                "data": time_labels,
-                "name": "Time (s)",
-                "nameLocation": "center",
-                "nameGap": 40,
-            },
-            "yAxis": {
-                "type": "value",
-                "name": waveform.units,
-                "nameRotate": 90,
-                "nameLocation": "center",
-                "nameGap": 40,
-            },
-            "series": [
-                {
-                    "name": waveform.units,
-                    "type": "line",
-                    "data": list(waveform.scaled_data),
-                    "emphasis": {"focus": "series"},
-                    "smooth": True,
-                    "seriesLayoutBy": "row",
+            graph = {
+                "animation": False,
+                "tooltip": {"trigger": "axis"},
+                "legend": {"data": [waveform.units]},
+                "xAxis": {
+                    "type": "category",
+                    "data": time_labels,
+                    "name": "Time (s)",
+                    "nameLocation": "center",
+                    "nameGap": 40,
                 },
-            ],
-        }
-        st_echarts(options=graph, height="400px", key="graph", width="100%")
+                "yAxis": {
+                    "type": "value",
+                    "name": waveform.units,
+                    "nameRotate": 90,
+                    "nameLocation": "center",
+                    "nameGap": 40,
+                },
+                "series": [
+                    {
+                        "name": waveform.units,
+                        "type": "line",
+                        "data": list(waveform.scaled_data),
+                        "emphasis": {"focus": "series"},
+                        "smooth": True,
+                        "seriesLayoutBy": "row",
+                    },
+                ],
+            }
+            st_echarts(options=graph, height="400px", key="graph", width="100%")
 
     with st.container(border=True):
         st.title("Trigger Settings")

--- a/examples/nidaqmx/nidaqmx_analog_output_voltage/nidaqmx_analog_output_voltage_panel.py
+++ b/examples/nidaqmx/nidaqmx_analog_output_voltage/nidaqmx_analog_output_voltage_panel.py
@@ -48,15 +48,13 @@ st.markdown(
     unsafe_allow_html=True,
 )
 
+if panel.get_value("is_running", False):
+    st.button("⏹️ Stop", key="stop_button", on_click=_click_stop)
+else:
+    st.button("▶️ Run", key="run_button", on_click=_click_start)
 
 with left_col:
     with st.container(border=True):
-        is_running = panel.get_value("is_running", False)
-        if is_running:
-            st.button("⏹️ Stop", key="stop_button", on_click=_click_stop)
-        elif not is_running:
-            run_button = st.button("▶️ Run", key="run_button", on_click=_click_start)
-
         st.title("Channel Settings")
         st.selectbox(
             options=panel.get_value("available_channel_names", [""]),

--- a/examples/nidaqmx/nidaqmx_analog_output_voltage/nidaqmx_analog_output_voltage_panel.py
+++ b/examples/nidaqmx/nidaqmx_analog_output_voltage/nidaqmx_analog_output_voltage_panel.py
@@ -2,8 +2,8 @@
 
 from typing import cast
 
-import hightime as ht
 import extra_streamlit_components as stx  # type: ignore[import-untyped]
+import hightime as ht
 import streamlit as st
 from nidaqmx.constants import Edge
 from nitypes.waveform import AnalogWaveform
@@ -13,11 +13,11 @@ import nipanel
 from nipanel.controls import enum_selectbox
 
 
-def click_start():
+def _click_start() -> None:
     panel.set_value("is_running", True)
 
 
-def click_stop():
+def _click_stop() -> None:
     panel.set_value("is_running", False)
 
 
@@ -53,9 +53,9 @@ with left_col:
     with st.container(border=True):
         is_running = panel.get_value("is_running", False)
         if is_running:
-            st.button("⏹️ Stop", key="stop_button", on_click=click_stop)
+            st.button("⏹️ Stop", key="stop_button", on_click=_click_stop)
         elif not is_running and panel.get_value("daq_error", "") == "":
-            run_button = st.button("▶️ Run", key="run_button", on_click=click_start)
+            run_button = st.button("▶️ Run", key="run_button", on_click=_click_start)
         else:
             st.error(
                 f"There was an error running the script. Fix the issue and re-run nidaqmx_analog_output_voltage.py \n\n {panel.get_value('daq_error', '')}"

--- a/examples/nidaqmx/nidaqmx_analog_output_voltage/nidaqmx_analog_output_voltage_panel.py
+++ b/examples/nidaqmx/nidaqmx_analog_output_voltage/nidaqmx_analog_output_voltage_panel.py
@@ -21,11 +21,8 @@ def _click_stop() -> None:
     panel.set_value("is_running", False)
 
 
-st.set_page_config(page_title="Voltage - Continuous Output", page_icon="📈", layout="wide")
-st.title("Voltage - Continuous Output")
+st.set_page_config(page_title="NI-DAQmx - Analog Output - Voltage", page_icon="📈", layout="wide")
 panel = nipanel.get_streamlit_panel_accessor()
-
-left_col, right_col = st.columns(2)
 
 st.markdown(
     """
@@ -48,14 +45,17 @@ st.markdown(
     unsafe_allow_html=True,
 )
 
+st.header("NI-DAQmx - Analog Output - Voltage")
 if panel.get_value("is_running", False):
     st.button("⏹️ Stop", key="stop_button", on_click=_click_stop)
 else:
     st.button("▶️ Run", key="run_button", on_click=_click_start)
 
+left_col, right_col = st.columns(2)
+
 with left_col:
     with st.container(border=True):
-        st.title("Channel Settings")
+        st.header("Channel Settings")
         st.selectbox(
             options=panel.get_value("available_channel_names", [""]),
             index=0,
@@ -79,7 +79,7 @@ with left_col:
             disabled=panel.get_value("is_running", False),
             key="min_value_voltage",
         )
-        st.title("Timing and Buffer Settings")
+        st.header("Timing and Buffer Settings")
 
         source = st.selectbox(
             "Sample Clock Source",
@@ -111,7 +111,7 @@ with left_col:
             step=1.0,
             disabled=True,
         )
-        st.title("Waveform Settings")
+        st.header("Waveform Settings")
         st.number_input(
             "Frequency",
             value=panel.get_value("frequency", 10.0),
@@ -141,7 +141,7 @@ with right_col:
         )
     else:
         with st.container(border=True):
-            st.title("Output")
+            st.header("Output")
 
             waveform = panel.get_value("waveform", AnalogWaveform())
             if waveform.sample_count == 0:
@@ -185,22 +185,22 @@ with right_col:
             st_echarts(options=graph, height="400px", key="graph", width="100%")
 
     with st.container(border=True):
-        st.title("Trigger Settings")
+        st.header("Trigger Settings")
         trigger_type = stx.tab_bar(
             data=[
                 stx.TabBarItemData(id=1, title="No Trigger", description=""),
                 stx.TabBarItemData(id=2, title="Digital Start", description=""),
-                stx.TabBarItemData(id=3, title="Digital Pause", description=""),
-                stx.TabBarItemData(id=4, title="Digital Reference", description=""),
-                stx.TabBarItemData(id=5, title="Analog Start", description=""),
-                stx.TabBarItemData(id=6, title="Analog Pause", description=""),
-                stx.TabBarItemData(id=7, title="Analog Reference", description=""),
             ],
             default=1,
         )
         trigger_type = int(trigger_type)  # pyright: ignore[reportArgumentType]
         panel.set_value("trigger_type", trigger_type)
 
+        if trigger_type == 1:
+            with st.container(border=True):
+                st.write(
+                    "To enable triggers, select a tab above, and configure the settings. Not all hardware supports all trigger types. Refer to your device documentation for more information."
+                )
         if trigger_type == 2:
             with st.container(border=True):
                 source = st.selectbox(
@@ -214,13 +214,3 @@ with right_col:
                     disabled=panel.get_value("is_running", False),
                     key="edge",
                 )
-        elif trigger_type == 1:
-            with st.container(border=True):
-                st.write(
-                    "To enable triggers, select a tab above, and configure the settings. Not all hardware supports all trigger types. Refer to your device documentation for more information."
-                )
-
-        else:
-            st.write(
-                "This trigger type is not supported in output tasks. Refer to your device documentation for more information on which triggers are supported."
-            )

--- a/examples/nidaqmx/nidaqmx_continuous_analog_input/nidaqmx_continuous_analog_input.py
+++ b/examples/nidaqmx/nidaqmx_continuous_analog_input/nidaqmx_continuous_analog_input.py
@@ -7,6 +7,7 @@ from typing import cast
 
 os.environ["NIDAQMX_ENABLE_WAVEFORM_SUPPORT"] = "1"
 import nidaqmx  # noqa: E402 # Must import after setting os environment variable
+import nidaqmx.system  # noqa: E402
 import numpy as np  # noqa: E402
 from nidaqmx.constants import (  # noqa: E402
     AcquisitionType,
@@ -16,6 +17,7 @@ from nidaqmx.constants import (  # noqa: E402
     TemperatureUnits,
     TerminalConfiguration,
     ThermocoupleType,
+    UsageTypeAI,
 )
 from nidaqmx.errors import DaqError  # noqa: E402
 from nitypes.waveform import AnalogWaveform  # noqa: E402
@@ -24,71 +26,89 @@ import nipanel  # noqa: E402
 
 panel_script_path = Path(__file__).with_name("nidaqmx_continuous_analog_input_panel.py")
 panel = nipanel.create_streamlit_panel(panel_script_path)
+panel.set_value("is_running", False)
+
+system = nidaqmx.system.System.local()
+
+available_voltage_channels = []
+available_thermocouple_channels = []
+for dev in system.devices:
+    for chan in dev.ai_physical_chans:
+        if UsageTypeAI.VOLTAGE in chan.ai_meas_types:
+            available_voltage_channels.append(chan.name)
+        if UsageTypeAI.TEMPERATURE_THERMOCOUPLE in chan.ai_meas_types:
+            available_thermocouple_channels.append(chan.name)
+panel.set_value("available_voltage_channels", available_voltage_channels)
+panel.set_value("available_thermocouple_channels", available_thermocouple_channels)
+
+print(f"Panel URL: {panel.panel_url}")
+print(f"Waiting for the 'Run' button to be pressed...")
+print(f"(Press Ctrl + C to quit)")
 
 try:
-    panel.set_value("daq_error", "")
-    panel.set_value("is_running", False)
-
-    print(f"Panel URL: {panel.panel_url}")
-    print(f"Waiting for the 'Run' button to be pressed...")
-    print(f"(Press Ctrl + C to quit)")
     while True:
         while not panel.get_value("is_running", False):
             time.sleep(0.1)
 
-        # How to use nidaqmx: https://nidaqmx-python.readthedocs.io/en/stable/
-        with nidaqmx.Task() as task:
-            task.ai_channels.add_ai_voltage_chan(
-                physical_channel="Dev1/ai0",
-                min_val=panel.get_value("voltage_min_value", -5.0),
-                max_val=panel.get_value("voltage_max_value", 5.0),
-                terminal_config=panel.get_value(
-                    "terminal_configuration", TerminalConfiguration.DEFAULT
-                ),
-            )
-            task.ai_channels.add_ai_thrmcpl_chan(
-                "Dev1/ai1",
-                min_val=panel.get_value("thermocouple_min_value", 0.0),
-                max_val=panel.get_value("thermocouple_max_value", 100.0),
-                units=panel.get_value("thermocouple_units", TemperatureUnits.DEG_C),
-                thermocouple_type=panel.get_value("thermocouple_type", ThermocoupleType.K),
-                cjc_source=panel.get_value(
-                    "thermocouple_cjc_source", CJCSource.CONSTANT_USER_VALUE
-                ),
-                cjc_val=panel.get_value("thermocouple_cjc_val", 25.0),
-            )
-            task.timing.cfg_samp_clk_timing(
-                rate=panel.get_value("sample_rate_input", 1000.0),
-                sample_mode=AcquisitionType.CONTINUOUS,
-                samps_per_chan=panel.get_value("samples_per_channel", 3000),
-            )
-            task.in_stream.configure_logging(
-                file_path=panel.get_value("tdms_file_path", "data.tdms"),
-                logging_mode=panel.get_value("logging_mode", LoggingMode.OFF),
-                operation=LoggingOperation.OPEN_OR_CREATE,
-            )
-            panel.set_value("sample_rate", task.timing.samp_clk_rate)
-            try:
-                print(f"Starting data acquisition...")
-                task.start()
+        print(f"Running...")
+        try:
+            # How to use nidaqmx: https://nidaqmx-python.readthedocs.io/en/stable/
+            panel.set_value("daq_error", "")
+            with nidaqmx.Task() as task:
+                task.ai_channels.add_ai_voltage_chan(
+                    physical_channel=panel.get_value("voltage_channel", ""),
+                    min_val=panel.get_value("voltage_min_value", -5.0),
+                    max_val=panel.get_value("voltage_max_value", 5.0),
+                    terminal_config=panel.get_value(
+                        "terminal_configuration", TerminalConfiguration.DEFAULT
+                    ),
+                )
+                task.ai_channels.add_ai_thrmcpl_chan(
+                    physical_channel=panel.get_value("thermocouple_channel", ""),
+                    min_val=panel.get_value("thermocouple_min_value", 0.0),
+                    max_val=panel.get_value("thermocouple_max_value", 100.0),
+                    units=panel.get_value("thermocouple_units", TemperatureUnits.DEG_C),
+                    thermocouple_type=panel.get_value("thermocouple_type", ThermocoupleType.K),
+                    cjc_source=panel.get_value(
+                        "thermocouple_cjc_source", CJCSource.CONSTANT_USER_VALUE
+                    ),
+                    cjc_val=panel.get_value("thermocouple_cjc_val", 25.0),
+                )
+                task.timing.cfg_samp_clk_timing(
+                    rate=panel.get_value("sample_rate_input", 1000.0),
+                    sample_mode=AcquisitionType.CONTINUOUS,
+                    samps_per_chan=panel.get_value("samples_per_channel", 3000),
+                )
+                task.in_stream.configure_logging(
+                    file_path=panel.get_value("tdms_file_path", "data.tdms"),
+                    logging_mode=panel.get_value("logging_mode", LoggingMode.OFF),
+                    operation=LoggingOperation.OPEN_OR_CREATE,
+                )
+                panel.set_value("sample_rate", task.timing.samp_clk_rate)
+                try:
+                    print(f"Starting data acquisition...")
+                    task.start()
 
-                while panel.get_value("is_running", False):
-                    waveforms = cast(
-                        list[AnalogWaveform[np.float64]],
-                        task.read_waveform(number_of_samples_per_channel=1000),
-                    )
-                    panel.set_value("voltage_waveform", waveforms[0])
-                    panel.set_value("thermocouple_waveform", waveforms[1])
-            except KeyboardInterrupt:
-                raise
-            finally:
-                print(f"Stopping data acquisition...")
-                task.stop()
-                panel.set_value("is_running", False)
+                    while panel.get_value("is_running", False):
+                        waveforms = cast(
+                            list[AnalogWaveform[np.float64]],
+                            task.read_waveform(number_of_samples_per_channel=1000),
+                        )
+                        panel.set_value("voltage_waveform", waveforms[0])
+                        panel.set_value("thermocouple_waveform", waveforms[1])
+                except KeyboardInterrupt:
+                    raise
+                finally:
+                    print(f"Stopping data acquisition...")
+                    task.stop()
+                    panel.set_value("is_running", False)
+                    print(f"Stopped")
 
-except DaqError as e:
-    daq_error = str(e)
-    print(daq_error)
-    panel.set_value("daq_error", daq_error)
+        except DaqError as e:
+            daq_error = str(e)
+            panel.set_value("daq_error", daq_error)
+            panel.set_value("is_running", False)
+            print(f"ERRORED")
+
 except KeyboardInterrupt:
     pass

--- a/examples/nidaqmx/nidaqmx_continuous_analog_input/nidaqmx_continuous_analog_input.py
+++ b/examples/nidaqmx/nidaqmx_continuous_analog_input/nidaqmx_continuous_analog_input.py
@@ -7,6 +7,7 @@ from typing import cast
 
 os.environ["NIDAQMX_ENABLE_WAVEFORM_SUPPORT"] = "1"
 import nidaqmx  # noqa: E402 # Must import after setting os environment variable
+import numpy as np  # noqa: E402
 from nidaqmx.constants import (  # noqa: E402
     AcquisitionType,
     CJCSource,
@@ -73,7 +74,8 @@ try:
 
                 while panel.get_value("is_running", False):
                     waveforms = cast(
-                        list[AnalogWaveform], task.read_waveform(number_of_samples_per_channel=1000)
+                        list[AnalogWaveform[np.float64]],
+                        task.read_waveform(number_of_samples_per_channel=1000),
                     )
                     panel.set_value("voltage_waveform", waveforms[0])
                     panel.set_value("thermocouple_waveform", waveforms[1])

--- a/examples/nidaqmx/nidaqmx_continuous_analog_input/nidaqmx_continuous_analog_input_panel.py
+++ b/examples/nidaqmx/nidaqmx_continuous_analog_input/nidaqmx_continuous_analog_input_panel.py
@@ -48,11 +48,10 @@ def _click_stop() -> None:
 
 
 panel = nipanel.get_streamlit_panel_accessor()
-is_running = panel.get_value("is_running", False)
 
-if is_running:
+if panel.get_value("is_running", False):
     st.button(r"⏹️ Stop", key="stop_button", on_click=_click_stop)
-elif not is_running:
+else:
     st.button(r"▶️ Run", key="run_button", on_click=_click_start)
 
 sample_rate = panel.get_value("sample_rate", 0.0)

--- a/examples/nidaqmx/nidaqmx_continuous_analog_input/nidaqmx_continuous_analog_input_panel.py
+++ b/examples/nidaqmx/nidaqmx_continuous_analog_input/nidaqmx_continuous_analog_input_panel.py
@@ -17,9 +17,9 @@ from streamlit_echarts import st_echarts
 import nipanel
 from nipanel.controls import enum_selectbox
 
-
-st.set_page_config(page_title="NI-DAQmx Example", page_icon="📈", layout="wide")
-st.title("Analog Input - Voltage and Thermocouple in a Single Task")
+st.set_page_config(
+    page_title="NI-DAQmx - Analog Input - Voltage and Thermocouple", page_icon="📈", layout="wide"
+)
 
 st.markdown(
     """
@@ -49,6 +49,7 @@ def _click_stop() -> None:
 
 panel = nipanel.get_streamlit_panel_accessor()
 
+st.header("NI-DAQmx - Analog Input - Voltage and Thermocouple")
 if panel.get_value("is_running", False):
     st.button(r"⏹️ Stop", key="stop_button", on_click=_click_stop)
 else:
@@ -198,7 +199,7 @@ with right_column:
     else:
         with st.container(border=True):
             # Graph section
-            st.header("Voltage & Thermocouple")
+            st.header("Acquired Data")
 
             thermocouple_waveform = panel.get_value("thermocouple_waveform", AnalogWaveform())
             voltage_waveform = panel.get_value("voltage_waveform", AnalogWaveform())

--- a/examples/nidaqmx/nidaqmx_continuous_analog_input/nidaqmx_continuous_analog_input_panel.py
+++ b/examples/nidaqmx/nidaqmx_continuous_analog_input/nidaqmx_continuous_analog_input_panel.py
@@ -39,11 +39,11 @@ st.markdown(
 )
 
 
-def click_start():
+def _click_start() -> None:
     panel.set_value("is_running", True)
 
 
-def click_stop():
+def _click_stop() -> None:
     panel.set_value("is_running", False)
 
 
@@ -51,9 +51,9 @@ panel = nipanel.get_streamlit_panel_accessor()
 is_running = panel.get_value("is_running", False)
 
 if is_running:
-    st.button(r"⏹️ Stop", key="stop_button", on_click=click_stop)
+    st.button(r"⏹️ Stop", key="stop_button", on_click=_click_stop)
 elif not is_running and panel.get_value("daq_error", "") == "":
-    st.button(r"▶️ Run", key="run_button", on_click=click_start)
+    st.button(r"▶️ Run", key="run_button", on_click=_click_start)
 else:
     st.error(
         f"There was an error running the script. Fix the issue and re-run nidaqmx_continuous_analog_input.py \n\n {panel.get_value('daq_error', '')}"

--- a/poetry.lock
+++ b/poetry.lock
@@ -1278,31 +1278,29 @@ toml = ">=0.10.1"
 
 [[package]]
 name = "nidaqmx"
-version = "1.2.0"
+version = "1.3.0.dev0"
 description = "NI-DAQmx Python API"
 optional = false
 python-versions = "<4.0,>=3.9"
 groups = ["examples"]
 files = [
-    {file = "nidaqmx-1.2.0-py3-none-any.whl", hash = "sha256:c2b8d6d39556a7920d966bf4aff6f5229e8df3bdf3b49c24dc68a2d42dfd5d30"},
-    {file = "nidaqmx-1.2.0.tar.gz", hash = "sha256:faeea9889a2dae03b7e23f525a44889264a5cfbf5590558e3792c28871620c87"},
+    {file = "nidaqmx-1.3.0.dev0-py3-none-any.whl", hash = "sha256:0402adef089a58e2eb8e2191210201f32f8ec49aec02f9dcaa0a3a751e5253e3"},
+    {file = "nidaqmx-1.3.0.dev0.tar.gz", hash = "sha256:672fdbcff7aec9fa1476cd96d000dc68112baef0d713946f368796e049aec5c7"},
 ]
 
 [package.dependencies]
-click = [
-    {version = ">=8.0.0", markers = "python_version >= \"3.10\" and python_version < \"4.0\""},
-    {version = ">=8.0.0,<8.2.0", markers = "python_version == \"3.9\""},
-]
+click = ">=8.0.0"
 deprecation = ">=2.1"
 distro = {version = ">=1.9.0", markers = "sys_platform == \"linux\""}
 hightime = ">=0.2.2"
+nitypes = ">=0.1.0dev10"
 numpy = [
-    {version = ">=1.26", markers = "python_version == \"3.12\""},
+    {version = ">=1.22", markers = "python_version >= \"3.9\" and python_version < \"3.13\""},
     {version = ">=2.1", markers = "python_version >= \"3.13\" and python_version < \"4.0\""},
-    {version = ">=1.22", markers = "python_version >= \"3.9\" and python_version < \"3.12\""},
 ]
 python-decouple = ">=3.8"
 requests = ">=2.25.0"
+typing_extensions = ">=4.0.0"
 tzlocal = ">=5.0,<6.0"
 
 [package.extras]
@@ -1348,7 +1346,7 @@ version = "0.1.0.dev10"
 description = "Data types for NI Python APIs"
 optional = false
 python-versions = "<4.0,>=3.9"
-groups = ["main"]
+groups = ["main", "examples"]
 files = [
     {file = "nitypes-0.1.0.dev10-py3-none-any.whl", hash = "sha256:c4f097ffdeaf05697a7752a1e2b712760b28e84a4f6f446b4b7b76b349927490"},
     {file = "nitypes-0.1.0.dev10.tar.gz", hash = "sha256:e319ebbdefca63db8e879b9f119cc4f76a086c550931dea2be0e33e9c10e9d9f"},
@@ -3365,4 +3363,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.9,<4.0,!=3.9.7"
-content-hash = "2919e6e9f65f22ab74586d2aba7b46dbc58b8afbb316f7f80b8483030ce41f8d"
+content-hash = "c7263b58c3c1e89dd34425fc2764c6bee106f5e7636356d4f93bb8a3d1e74126"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,7 +93,7 @@ optional = true
 [tool.poetry.group.examples.dependencies]
 streamlit-echarts = ">=0.4.0"
 extra-streamlit-components = "^0.1.80"
-nidaqmx = { version = ">=0.8.0", allow-prereleases = true }
+nidaqmx = { version = ">=1.3.0-dev0", allow-prereleases = true }
 niscope = "^1.4.9"
 
 [build-system]


### PR DESCRIPTION
### What does this Pull Request accomplish?

This updates the nidaqmx examples to use the new `task.read_waveform()` and `task.write_waveform()` methods.

I also changed how the run and stop buttons work. Trying to use `panel.get_value("run_button", False)` is just not reliable, so I changed it to use `panel.get_value("is_running", False)` instead, and the buttons now explicitly set `is_running` when clicked.

I also improved error handling. Now, instead of the script ending when a DAQ error happens, the script loops back to the stopped state, with a message (taking the place of the graph) saying what the error is, so that the user can change the configuration and click Run again.

I also added filters on the channel selectors so that only compatible channels are presented.

I also made some changes to improve consistency between the three daq examples.

### Why should this Pull Request be merged?

[AB#3353661](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/3353661)

### What testing has been done?

Ran the three examples:

examples/nidaqmx/nidaqmx_analog_input_filtering/nidaqmx_analog_input_filtering.py

<img width="931" height="835" alt="image" src="https://github.com/user-attachments/assets/5196455f-15f8-4944-9878-b08df4f62078" />

---

examples/nidaqmx/nidaqmx_analog_output_voltage/nidaqmx_analog_output_voltage.py

<img width="907" height="763" alt="image" src="https://github.com/user-attachments/assets/e5018364-d124-479e-ac94-29e389314f09" />


---

examples/nidaqmx/nidaqmx_continuous_analog_input/nidaqmx_continuous_analog_input.py

<img width="927" height="888" alt="image" src="https://github.com/user-attachments/assets/19ad0455-fea9-432f-90b7-b0a8b0d2dca8" />
