### PR TITLE
add an nidaqmx example with an fft

### DIFF
--- a/examples/nidaqmx/nidaqmx_analog_input_fft/README.md
+++ b/examples/nidaqmx/nidaqmx_analog_input_fft/README.md
@@ -2,7 +2,7 @@
 
 ### Overview
 
-This is a nipanel example that displays an interactive Streamlit panel and updates continuous analog input samples while measuring and displaying the FFT Spectrum Magnitude.
+This is a nipanel example that acquires a continuous amount of data using the DAQ device's internal clock and graphs the acquired data in both the time domain and frequency domain in an interactive Streamlit panel.
 
 ### Features
 

--- a/examples/nidaqmx/nidaqmx_analog_input_fft/README.md
+++ b/examples/nidaqmx/nidaqmx_analog_input_fft/README.md
@@ -1,22 +1,22 @@
-Prerequisites
-===============
-Requires a Physical or Simulated Device : https://github.com/ni/nidaqmx-python/blob/master/README.rst (Getting Started Section)
-
-## Sample
+## Overview
 
 This is a nipanel example that displays an interactive Streamlit app and updates continuous analog input samples while measuring and displaying the FFT Spectrum Magnitude.
 
-### Feature
+### Features
 
-- Supports various data types
+- NI-DAQmx Python configuration and acquisition
+- Displays data in an interactive chart using ECharts
+- Updates automatically as new data is acquired
 
-### Required Software
+### Prerequisites
 
 - Python 3.10 or later
+- InstrumentStudio 2026 Q1 or later
+- A Physical or Simulated Device : https://github.com/ni/nidaqmx-python/blob/master/README.rst (Getting Started Section)
 
 ### Usage
 
 ```pwsh
 poetry install --with examples
-poetry run python examples\nidaqmx\nidaqmx_analog_input_fft\nidaqmx_analog_input_fft.py
+poetry run python examples\nidaqmx\nidaqmx_continuous_analog_input\nidaqmx_continuous_analog_input.py
 ```

--- a/examples/nidaqmx/nidaqmx_analog_input_fft/README.md
+++ b/examples/nidaqmx/nidaqmx_analog_input_fft/README.md
@@ -1,6 +1,8 @@
-## Overview
+# NI-DAQmx Analog Input with FFT Example
 
-This is a nipanel example that displays an interactive Streamlit app and updates continuous analog input samples while measuring and displaying the FFT Spectrum Magnitude.
+### Overview
+
+This is a nipanel example that displays an interactive Streamlit panel and updates continuous analog input samples while measuring and displaying the FFT Spectrum Magnitude.
 
 ### Features
 
@@ -12,11 +14,11 @@ This is a nipanel example that displays an interactive Streamlit app and updates
 
 - Python 3.10 or later
 - InstrumentStudio 2026 Q1 or later
-- A Physical or Simulated Device : https://github.com/ni/nidaqmx-python/blob/master/README.rst (Getting Started Section)
+- A physical or simulated device, refer to the [NI-DAQmx Python README (Getting Started section)](https://github.com/ni/nidaqmx-python/blob/master/README.rst#getting-started)
 
 ### Usage
 
 ```pwsh
 poetry install --with examples
-poetry run python examples\nidaqmx\nidaqmx_continuous_analog_input\nidaqmx_continuous_analog_input.py
+poetry run python examples\nidaqmx\nidaqmx_analog_input_fft\nidaqmx_analog_input_fft.py
 ```

--- a/examples/nidaqmx/nidaqmx_analog_input_fft/README.md
+++ b/examples/nidaqmx/nidaqmx_analog_input_fft/README.md
@@ -1,0 +1,22 @@
+Prerequisites
+===============
+Requires a Physical or Simulated Device : https://github.com/ni/nidaqmx-python/blob/master/README.rst (Getting Started Section)
+
+## Sample
+
+This is a nipanel example that displays an interactive Streamlit app and updates continuous analog input examples.
+
+### Feature
+
+- Supports various data types
+
+### Required Software
+
+- Python 3.10 or later
+
+### Usage
+
+```pwsh
+poetry install --with examples
+poetry run python examples\nidaqmx\nidaqmx_continuous_analog_input\nidaqmx_continuous_analog_input.py
+```

--- a/examples/nidaqmx/nidaqmx_analog_input_fft/README.md
+++ b/examples/nidaqmx/nidaqmx_analog_input_fft/README.md
@@ -4,7 +4,7 @@ Requires a Physical or Simulated Device : https://github.com/ni/nidaqmx-python/b
 
 ## Sample
 
-This is a nipanel example that displays an interactive Streamlit app and updates continuous analog input examples.
+This is a nipanel example that displays an interactive Streamlit app and updates continuous analog input samples while measuring and displaying the FFT Spectrum Magnitude.
 
 ### Feature
 
@@ -18,5 +18,5 @@ This is a nipanel example that displays an interactive Streamlit app and updates
 
 ```pwsh
 poetry install --with examples
-poetry run python examples\nidaqmx\nidaqmx_continuous_analog_input\nidaqmx_continuous_analog_input.py
+poetry run python examples\nidaqmx\nidaqmx_analog_input_fft\nidaqmx_analog_input_fft.py
 ```

--- a/examples/nidaqmx/nidaqmx_analog_input_fft/nidaqmx_analog_input_fft.py
+++ b/examples/nidaqmx/nidaqmx_analog_input_fft/nidaqmx_analog_input_fft.py
@@ -60,21 +60,21 @@ try:
                 panel.set_value("sample_rate", task.timing.samp_clk_rate)
                 try:
                     print(f"Starting data acquisition...")
-                    samples_per_channel=panel.get_value("samples_per_channel", 100)
+                    samples_per_channel = panel.get_value("samples_per_channel", 100)
                     task.start()
 
                     while panel.get_value("is_running", False):
                         waveform = cast(
                             AnalogWaveform[np.float64],
-                            task.read_waveform(
-                                number_of_samples_per_channel=samples_per_channel
-                            ),
+                            task.read_waveform(number_of_samples_per_channel=samples_per_channel),
                         )
                         panel.set_value("voltage_waveform", waveform)
 
                         # calculate the Discrete Fourier Transform
                         fft = np.fft.fft(waveform.scaled_data)
-                        dft_sample_freqs = np.fft.fftfreq(waveform.sample_count, d=waveform.timing.sample_interval.total_seconds())
+                        dft_sample_freqs = np.fft.fftfreq(
+                            waveform.sample_count, d=waveform.timing.sample_interval.total_seconds()
+                        )
 
                         # convert to decibels
                         magnitudes = np.abs(fft)
@@ -82,7 +82,7 @@ try:
                         dbs = 20 * np.log10(normalized_magnitudes)
 
                         # only graph up to Nyquist
-                        num_freqs_to_graph = samples_per_channel//2
+                        num_freqs_to_graph = samples_per_channel // 2
                         panel.set_value("fft_freqs", dft_sample_freqs[0:num_freqs_to_graph])
                         panel.set_value("fft_mags", dbs[0:num_freqs_to_graph])
                 except KeyboardInterrupt:

--- a/examples/nidaqmx/nidaqmx_analog_input_fft/nidaqmx_analog_input_fft.py
+++ b/examples/nidaqmx/nidaqmx_analog_input_fft/nidaqmx_analog_input_fft.py
@@ -1,4 +1,11 @@
-"""Data acquisition script that continuously acquires analog input data."""
+"""Example of analog input voltage acquisition with a Fast Fourier Transform.
+
+This example demonstrates how to acquire a continuous amount of data using the
+DAQ device's internal clock. The settings are configured from the Streamlit
+panel, and the acquired data is displayed on a graph. An FFT is computed from
+the acquired data and displayed on a separate graph. Refer to the panel script
+for details: nidaqmx_analog_input_fft_panel.py
+"""
 
 import time
 from pathlib import Path
@@ -64,9 +71,8 @@ try:
                     task.start()
 
                     while panel.get_value("is_running", False):
-                        waveform = cast(
-                            AnalogWaveform[np.float64],
-                            task.read_waveform(number_of_samples_per_channel=samples_per_channel),
+                        waveform: AnalogWaveform[np.float64] = task.read_waveform(
+                            samples_per_channel
                         )
                         panel.set_value("voltage_waveform", waveform)
 

--- a/examples/nidaqmx/nidaqmx_analog_input_fft/nidaqmx_analog_input_fft.py
+++ b/examples/nidaqmx/nidaqmx_analog_input_fft/nidaqmx_analog_input_fft.py
@@ -9,7 +9,6 @@ for details: nidaqmx_analog_input_fft_panel.py
 
 import time
 from pathlib import Path
-from typing import cast
 
 import nidaqmx
 import nidaqmx.system

--- a/examples/nidaqmx/nidaqmx_analog_input_fft/nidaqmx_analog_input_fft.py
+++ b/examples/nidaqmx/nidaqmx_analog_input_fft/nidaqmx_analog_input_fft.py
@@ -9,6 +9,7 @@ for details: nidaqmx_analog_input_fft_panel.py
 
 import time
 from pathlib import Path
+from typing import cast
 
 import nidaqmx
 import nidaqmx.system
@@ -70,8 +71,9 @@ try:
                     task.start()
 
                     while panel.get_value("is_running", False):
-                        waveform: AnalogWaveform[np.float64] = task.read_waveform(
-                            samples_per_channel
+                        waveform = cast(
+                            AnalogWaveform[np.float64],
+                            task.read_waveform(number_of_samples_per_channel=samples_per_channel),
                         )
                         panel.set_value("voltage_waveform", waveform)
 

--- a/examples/nidaqmx/nidaqmx_analog_input_fft/nidaqmx_analog_input_fft.py
+++ b/examples/nidaqmx/nidaqmx_analog_input_fft/nidaqmx_analog_input_fft.py
@@ -1,0 +1,103 @@
+"""Data acquisition script that continuously acquires analog input data."""
+
+import time
+from pathlib import Path
+from typing import cast
+
+import nidaqmx
+import nidaqmx.system
+import numpy as np
+from nidaqmx.constants import (
+    AcquisitionType,
+    TerminalConfiguration,
+    UsageTypeAI,
+)
+from nidaqmx.errors import DaqError
+from nitypes.waveform import AnalogWaveform
+
+import nipanel
+
+panel_script_path = Path(__file__).with_name("nidaqmx_analog_input_fft_panel.py")
+panel = nipanel.create_streamlit_panel(panel_script_path)
+panel.set_value("is_running", False)
+
+system = nidaqmx.system.System.local()
+
+available_voltage_channels = []
+for dev in system.devices:
+    for chan in dev.ai_physical_chans:
+        if UsageTypeAI.VOLTAGE in chan.ai_meas_types:
+            available_voltage_channels.append(chan.name)
+panel.set_value("available_voltage_channels", available_voltage_channels)
+
+print(f"Panel URL: {panel.panel_url}")
+print(f"Waiting for the 'Run' button to be pressed...")
+print(f"(Press Ctrl + C to quit)")
+
+try:
+    while True:
+        while not panel.get_value("is_running", False):
+            time.sleep(0.1)
+
+        print(f"Running...")
+        try:
+            # How to use nidaqmx: https://nidaqmx-python.readthedocs.io/en/stable/
+            panel.set_value("daq_error", "")
+            with nidaqmx.Task() as task:
+                task.ai_channels.add_ai_voltage_chan(
+                    physical_channel=panel.get_value("voltage_channel", ""),
+                    min_val=panel.get_value("voltage_min_value", -5.0),
+                    max_val=panel.get_value("voltage_max_value", 5.0),
+                    terminal_config=panel.get_value(
+                        "terminal_configuration", TerminalConfiguration.DEFAULT
+                    ),
+                )
+                task.timing.cfg_samp_clk_timing(
+                    rate=panel.get_value("sample_rate_input", 1000.0),
+                    sample_mode=AcquisitionType.CONTINUOUS,
+                    samps_per_chan=panel.get_value("samples_per_channel", 100),
+                )
+                panel.set_value("sample_rate", task.timing.samp_clk_rate)
+                try:
+                    print(f"Starting data acquisition...")
+                    samples_per_channel=panel.get_value("samples_per_channel", 100)
+                    task.start()
+
+                    while panel.get_value("is_running", False):
+                        waveform = cast(
+                            AnalogWaveform[np.float64],
+                            task.read_waveform(
+                                number_of_samples_per_channel=samples_per_channel
+                            ),
+                        )
+                        panel.set_value("voltage_waveform", waveform)
+
+                        # calculate the Discrete Fourier Transform
+                        fft = np.fft.fft(waveform.scaled_data)
+                        dft_sample_freqs = np.fft.fftfreq(waveform.sample_count, d=waveform.timing.sample_interval.total_seconds())
+
+                        # convert to decibels
+                        magnitudes = np.abs(fft)
+                        normalized_magnitudes = magnitudes / np.max(magnitudes)
+                        dbs = 20 * np.log10(normalized_magnitudes)
+
+                        # only graph up to Nyquist
+                        num_freqs_to_graph = samples_per_channel//2
+                        panel.set_value("fft_freqs", dft_sample_freqs[0:num_freqs_to_graph])
+                        panel.set_value("fft_mags", dbs[0:num_freqs_to_graph])
+                except KeyboardInterrupt:
+                    raise
+                finally:
+                    print(f"Stopping data acquisition...")
+                    task.stop()
+                    panel.set_value("is_running", False)
+                    print(f"Stopped")
+
+        except DaqError as e:
+            daq_error = str(e)
+            panel.set_value("daq_error", daq_error)
+            panel.set_value("is_running", False)
+            print(f"ERRORED")
+
+except KeyboardInterrupt:
+    pass

--- a/examples/nidaqmx/nidaqmx_analog_input_fft/nidaqmx_analog_input_fft_panel.py
+++ b/examples/nidaqmx/nidaqmx_analog_input_fft/nidaqmx_analog_input_fft_panel.py
@@ -1,0 +1,221 @@
+"""Streamlit visualization script to display data acquired by nidaqmx_continuous_analog_input.py."""
+
+from typing import cast
+
+import hightime as ht
+import streamlit as st
+from nidaqmx.constants import (
+    TerminalConfiguration,
+)
+from nitypes.waveform import AnalogWaveform
+from streamlit_echarts import st_echarts
+
+import nipanel
+from nipanel.controls import enum_selectbox
+
+st.set_page_config(
+    page_title="NI-DAQmx - Analog Input - Voltage with FFT", page_icon="📈", layout="wide"
+)
+
+st.markdown(
+    """
+    <style>
+    div[data-baseweb="select"] {
+        max-width: 250px !important;
+    }
+    div.stNumberInput {
+        max-width: 250px !important;
+    }
+    div.stTextInput {
+        max-width: 250px !important;
+    }
+    </style>
+    """,
+    unsafe_allow_html=True,
+)
+
+
+def _click_start() -> None:
+    panel.set_value("is_running", True)
+
+
+def _click_stop() -> None:
+    panel.set_value("is_running", False)
+
+
+panel = nipanel.get_streamlit_panel_accessor()
+
+st.header("NI-DAQmx - Analog Input - Voltage with FFT")
+if panel.get_value("is_running", False):
+    st.button(r"⏹️ Stop", key="stop_button", on_click=_click_stop)
+else:
+    st.button(r"▶️ Run", key="run_button", on_click=_click_start)
+
+sample_rate = panel.get_value("sample_rate", 0.0)
+
+# Create two-column layout for the entire interface
+left_column, right_column = st.columns([1, 1])
+
+# Left column - Channel tabs and Timing Settings
+with left_column:
+    # Channel Settings tabs
+    with st.container(border=True):
+        st.header("Channel Settings")
+        voltage_tab = st.tabs(["Voltage"])[0]
+
+        voltage_tab.header("Voltage")
+        with voltage_tab:
+            channel_left_column, channel_right_column = st.columns(2)
+            with channel_left_column:
+                st.selectbox(
+                    options=panel.get_value("available_voltage_channels", [""]),
+                    index=0,
+                    label="Voltage Channel",
+                    disabled=panel.get_value("is_running", False),
+                    key="voltage_channel",
+                )
+                st.number_input(
+                    "Min Value",
+                    value=-5.0,
+                    step=0.1,
+                    disabled=panel.get_value("is_running", False),
+                    key="voltage_min_value",
+                )
+                st.number_input(
+                    "Max Value",
+                    value=5.0,
+                    step=0.1,
+                    disabled=panel.get_value("is_running", False),
+                    key="voltage_max_value",
+                )
+            with channel_right_column:
+                enum_selectbox(
+                    panel,
+                    label="Terminal Configuration",
+                    value=TerminalConfiguration.DEFAULT,
+                    disabled=panel.get_value("is_running", False),
+                    key="terminal_configuration",
+                )
+
+    # Timing Settings section in left column
+    with st.container(border=True):
+        st.header("Timing Settings")
+        timing_left_column, timing_right_column = st.columns(2)
+        with timing_left_column:
+            st.selectbox(
+                options=["OnboardClock"],
+                label="Sample Clock Source",
+                disabled=True,
+            )
+            st.number_input(
+                "Sample Rate",
+                value=1000.0,
+                step=100.0,
+                min_value=1.0,
+                disabled=panel.get_value("is_running", False),
+                key="sample_rate_input",
+            )
+        with timing_right_column:
+            st.number_input(
+                "Samples to Read",
+                value=1000,
+                step=100,
+                min_value=10,
+                disabled=panel.get_value("is_running", False),
+                key="samples_per_channel",
+            )
+            st.text_input(
+                label="Actual Sample Rate",
+                value=str(sample_rate) if sample_rate else "",
+                disabled=True,
+            )
+
+# Right column - Graph
+with right_column:
+    if panel.get_value("daq_error", "") != "":
+        st.error(
+            f"There was an error running the script. Fix the issue and click Run again. \n\n {panel.get_value('daq_error', '')}"
+        )
+    else:
+        with st.container(border=True):
+            # Voltage Data Graph section
+            st.header("Acquired Data")
+
+            voltage_waveform = panel.get_value("voltage_waveform", AnalogWaveform())
+            if voltage_waveform.sample_count == 0:
+                time_labels = ["00:00:00.000"]
+            else:
+                timestamps = cast(
+                    list[ht.datetime],
+                    list(voltage_waveform.timing.get_timestamps(0, voltage_waveform.sample_count)),
+                )
+                time_labels = [
+                    f"{ts.hour:02d}:{ts.minute:02d}:{ts.second:02d}.{ts.microsecond//1000:03d}"
+                    for ts in timestamps
+                ]
+
+            voltage_graph = {
+                "animation": False,
+                "tooltip": {"trigger": "axis"},
+                "legend": {"data": [voltage_waveform.units]},
+                "xAxis": {
+                    "type": "category",
+                    "data": time_labels,
+                    "name": "Time",
+                    "nameLocation": "center",
+                    "nameGap": 40,
+                },
+                "yAxis": {
+                    "type": "value",
+                    "name": "Measurement",
+                    "nameRotate": 90,
+                    "nameLocation": "center",
+                    "nameGap": 40,
+                },
+                "series": [
+                    {
+                        "name": voltage_waveform.units,
+                        "type": "line",
+                        "data": list(voltage_waveform.scaled_data),
+                        "emphasis": {"focus": "series"},
+                        "smooth": True,
+                        "seriesLayoutBy": "row",
+                    },
+                ],
+            }
+            st_echarts(options=voltage_graph, height="300px", key="voltage_graph")
+
+            frequencies = panel.get_value("fft_freqs", [0.0])
+            magnitudes = panel.get_value("fft_mags", [0.0])
+            fft_data = [{"value": [x, y]} for x, y in zip(frequencies, magnitudes)]
+
+            fft_graph = {
+                "animation": False,
+                "tooltip": {"trigger": "axis"},
+                "legend": {"data": ["Magnitude"]},
+                "xAxis": {
+                    "type": "value",
+                    "name": "Frequency",
+                    "nameLocation": "center",
+                    "nameGap": 40,
+                },
+                "yAxis": {
+                    "type": "value",
+                    "name": "Magnitude",
+                    "nameRotate": 90,
+                    "nameLocation": "center",
+                    "nameGap": 40,
+                },
+                "series": [
+                    {
+                        "name": "Magnitude",
+                        "type": "line",
+                        "data": fft_data,
+                        "emphasis": {"focus": "series"},
+                        "smooth": True,
+                        "seriesLayoutBy": "row",
+                    },
+                ],
+            }
+            st_echarts(options=fft_graph, height="300px", key="fft_graph")
+

--- a/examples/nidaqmx/nidaqmx_analog_input_fft/nidaqmx_analog_input_fft_panel.py
+++ b/examples/nidaqmx/nidaqmx_analog_input_fft/nidaqmx_analog_input_fft_panel.py
@@ -218,4 +218,3 @@ with right_column:
                 ],
             }
             st_echarts(options=fft_graph, height="300px", key="fft_graph")
-


### PR DESCRIPTION
### What does this Pull Request accomplish?

It adds a new example that is a single channel DAQ acquisition with an FFT as two separate graphs.

<img width="1574" height="750" alt="image" src="https://github.com/user-attachments/assets/38bc53ae-6bad-402c-bd31-cdb16ba454ea" />

### Why should this Pull Request be merged?

It's neat!

### What testing has been done?

Hand tested with a mioDAQ.